### PR TITLE
Screen capture: adapt WebRTC output format on iOS

### DIFF
--- a/Sources/PexipRTC/Internal/Capturers/WebRTCScreenCapturer.swift
+++ b/Sources/PexipRTC/Internal/Capturers/WebRTCScreenCapturer.swift
@@ -75,6 +75,7 @@ final class WebRTCScreenCapturer: RTCVideoCapturer, ScreenMediaCapturerDelegate 
 
     func stopCapture(reason: ScreenCaptureStopReason?) async throws {
         try await capturer.stopCapture(reason: reason)
+        startTimeNs = nil
         logger?.info("Screen capture did stop.")
     }
 

--- a/Sources/PexipRTC/Internal/Capturers/WebRTCScreenCapturer.swift
+++ b/Sources/PexipRTC/Internal/Capturers/WebRTCScreenCapturer.swift
@@ -63,10 +63,14 @@ final class WebRTCScreenCapturer: RTCVideoCapturer, ScreenMediaCapturerDelegate 
 
     func startCapture(withVideoProfile videoProfile: QualityProfile) async throws {
         self.videoProfile = videoProfile
+        #if os(iOS)
+        try await capturer.startCapture(atFps: videoProfile.fps)
+        #else
         try await capturer.startCapture(
             atFps: videoProfile.fps,
             outputDimensions: videoProfile.dimensions
         )
+        #endif
     }
 
     func stopCapture(reason: ScreenCaptureStopReason?) async throws {
@@ -80,17 +84,22 @@ final class WebRTCScreenCapturer: RTCVideoCapturer, ScreenMediaCapturerDelegate 
         _ capturer: ScreenMediaCapturer,
         didCaptureVideoFrame videoFrame: VideoFrame
     ) {
+        #if os(iOS)
+
+        // Screen frames are always portrait while video profile is landscape.
+        let adaptedDimensions = videoFrame.adaptedContentDimensions(
+            to: CMVideoDimensions(
+                width: Int32(videoProfile.height),
+                height: Int32(videoProfile.width)
+            )
+        )
+        let rtcPixelBuffer = RTCCVPixelBuffer(pixelBuffer: videoFrame.pixelBuffer)
+
+        #else
         let cropDimensions = videoFrame.contentDimensions
         let adaptedDimensions = videoFrame.adaptedContentDimensions(
             to: videoProfile.dimensions
         )
-
-        videoSource.adaptOutputFormat(
-            toWidth: adaptedDimensions.width,
-            height: adaptedDimensions.height,
-            fps: Int32(videoProfile.fps)
-        )
-
         let rtcPixelBuffer = RTCCVPixelBuffer(
             pixelBuffer: videoFrame.pixelBuffer,
             adaptedWidth: adaptedDimensions.width,
@@ -99,12 +108,19 @@ final class WebRTCScreenCapturer: RTCVideoCapturer, ScreenMediaCapturerDelegate 
             cropHeight: cropDimensions.height,
             cropX: videoFrame.contentX,
             cropY: videoFrame.contentY
-        )
+        ).toI420()
+
+        #endif
 
         startTimeNs = startTimeNs ?? videoFrame.displayTimeNs
+        videoSource.adaptOutputFormat(
+            toWidth: adaptedDimensions.width,
+            height: adaptedDimensions.height,
+            fps: Int32(videoProfile.fps)
+        )
 
         let rtcVideoFrame = RTCVideoFrame(
-            buffer: rtcPixelBuffer.toI420(),
+            buffer: rtcPixelBuffer,
             rotation: videoFrame.orientation.rtcRotation,
             timeStampNs: Int64(videoFrame.displayTimeNs - startTimeNs!)
         )

--- a/Sources/PexipRTC/WebRTCMediaFactory.swift
+++ b/Sources/PexipRTC/WebRTCMediaFactory.swift
@@ -114,7 +114,8 @@ public final class WebRTCMediaFactory: MediaFactory {
     ) -> ScreenMediaTrack {
         let screenMediaCapturer = BroadcastScreenCapturer(
             appGroup: appGroup,
-            broadcastUploadExtension: broadcastUploadExtension
+            broadcastUploadExtension: broadcastUploadExtension,
+            defaultFps: defaultVideoProfile.fps
         )
         return createScreenMediaTrack(
             screenMediaCapturer: screenMediaCapturer,

--- a/Sources/PexipScreenCapture/Shared/ScreenMediaCapturer.swift
+++ b/Sources/PexipScreenCapture/Shared/ScreenMediaCapturer.swift
@@ -52,6 +52,18 @@ public protocol ScreenMediaCapturer: AnyObject {
      */
     func startCapture(atFps fps: UInt) async throws
 
+    /**
+     Starts screen capture with the given video quality profile.
+     - Parameters:
+        - fps: The FPS of a video stream (1...60)
+        - outputDimensions: The dimensions of the output video.
+     */
+    @available(*, deprecated, message: "Use startCapture(atFps:) instead.")
+    func startCapture(
+        atFps fps: UInt,
+        outputDimensions: CMVideoDimensions
+    ) async throws
+
     #else
 
     /**

--- a/Sources/PexipScreenCapture/Shared/ScreenMediaCapturer.swift
+++ b/Sources/PexipScreenCapture/Shared/ScreenMediaCapturer.swift
@@ -43,6 +43,17 @@ public protocol ScreenMediaCapturerDelegate: AnyObject {
 public protocol ScreenMediaCapturer: AnyObject {
     var delegate: ScreenMediaCapturerDelegate? { get set }
 
+    #if os(iOS)
+
+    /**
+     Starts screen capture with the given fps.
+     - Parameters:
+        - fps: The FPS of a video stream (15...30)
+     */
+    func startCapture(atFps fps: UInt) async throws
+
+    #else
+
     /**
      Starts screen capture with the given video quality profile.
      - Parameters:
@@ -53,6 +64,8 @@ public protocol ScreenMediaCapturer: AnyObject {
         atFps fps: UInt,
         outputDimensions: CMVideoDimensions
     ) async throws
+
+    #endif
 
     /// Stops screen capture
     func stopCapture() async throws

--- a/Sources/PexipScreenCapture/iOS/BroadcastScreenCapturer.swift
+++ b/Sources/PexipScreenCapture/iOS/BroadcastScreenCapturer.swift
@@ -117,6 +117,14 @@ public final class BroadcastScreenCapturer: ScreenMediaCapturer {
         }
     }
 
+    @available(*, deprecated, message: "Use startCapture(atFps:) instead.")
+    public func startCapture(
+        atFps fps: UInt,
+        outputDimensions: CMVideoDimensions
+    ) async throws {
+        try await startCapture(atFps: fps)
+    }
+
     public func stopCapture() throws {
         try stopCapture(reason: nil)
     }

--- a/Sources/PexipScreenCapture/iOS/BroadcastScreenCapturer.swift
+++ b/Sources/PexipScreenCapture/iOS/BroadcastScreenCapturer.swift
@@ -94,16 +94,11 @@ public final class BroadcastScreenCapturer: ScreenMediaCapturer {
     // MARK: - Internal
 
     /**
-     Starts the screen capture with the given video quality profile.
-
+     Starts screen capture with the given fps.
      - Parameters:
-        - fps: The FPS of a video stream (1...30)
-        - outputDimensions: The dimensions of the output video.
+        - fps: The FPS of a video stream (15...30)
      */
-    public func startCapture(
-        atFps fps: UInt,
-        outputDimensions: CMVideoDimensions
-    ) async throws {
+    public func startCapture(atFps fps: UInt) async throws {
         guard !isCapturing.value else {
             return
         }

--- a/Tests/PexipScreenCaptureTests/iOS/BroadcastScreenCapturerTests.swift
+++ b/Tests/PexipScreenCaptureTests/iOS/BroadcastScreenCapturerTests.swift
@@ -194,31 +194,20 @@ final class BroadcastScreenCapturerTests: XCTestCase {
     }
 
     func testStartCapture() async throws {
-        try await capturer.startCapture(
-            atFps: 30,
-            outputDimensions: outputDimensions
-        )
-
+        try await capturer.startCapture(atFps: 30)
         XCTAssertEqual(userDefaults.broadcastFps, 30)
     }
 
     func testStartCaptureWhenCapturing() async throws {
         // 1. Open broadcast extension dialogue
-        try await capturer.startCapture(
-            atFps: 25,
-            outputDimensions: outputDimensions
-        )
-
+        try await capturer.startCapture(atFps: 25)
         XCTAssertEqual(userDefaults.broadcastFps, 25)
 
         // 2. Start receiver
         startReceiver()
 
         // 3. Try to start capture again
-        try await capturer.startCapture(
-            atFps: 15,
-            outputDimensions: outputDimensions
-        )
+        try await capturer.startCapture(atFps: 15)
 
         // 4. Assert that there were no fps changes
         XCTAssertEqual(userDefaults.broadcastFps, 25)


### PR DESCRIPTION
- Create `RTCCVPixelBuffer` without cropping on iOS
- Remove unused `outputDimensions` parameter in `startCapture` function on iOS
- Create BroadcastScreenCapturer with fps in WebRTCMediaFactory