### PR TITLE
Fix new Xcode and SwiftLint warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -69,6 +69,9 @@ identifier_name:
   excluded:
     - id
     - to
+attributes:
+  always_on_same_line:
+    ["@AppStorage", "@NSApplicationDelegateAdaptor"]
 file_header:
   severity: error
   required_pattern: |

--- a/Examples/Conference/App/Shared/App/AppCoordinator.swift
+++ b/Examples/Conference/App/Shared/App/AppCoordinator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,8 +46,7 @@ struct AppCoordinator: View {
         #endif
     }
 
-    @ViewBuilder
-    private var currentScreen: some View {
+    @ViewBuilder private var currentScreen: some View {
         switch screen {
         case .displayName:
             viewFactory.displayNameView(onComplete: {

--- a/Examples/Conference/App/Shared/Components/LargeTextFieldStyle.swift
+++ b/Examples/Conference/App/Shared/Components/LargeTextFieldStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,4 +28,5 @@ struct LargeTextFieldStyle: TextFieldStyle {
                 .fill(Material.ultraThin)
         )
     }
+    // swiftlint:enable identifier_name
 }

--- a/Examples/Conference/App/Shared/Screens/Conference/CallView.swift
+++ b/Examples/Conference/App/Shared/Screens/Conference/CallView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -192,8 +192,7 @@ private extension CallView {
         }
     }
 
-    @ViewBuilder
-    var presenterNameLabel: some View {
+    @ViewBuilder var presenterNameLabel: some View {
         presenterName.map { name in
             Text("\(name) presenting")
                 .padding(.horizontal, 10)

--- a/Examples/Conference/App/Shared/Screens/Conference/ConferenceView.swift
+++ b/Examples/Conference/App/Shared/Screens/Conference/ConferenceView.swift
@@ -121,8 +121,7 @@ struct ConferenceView: View {
         )
     }
 
-    @ViewBuilder
-    private var connectedView: some View {
+    @ViewBuilder private var connectedView: some View {
         GeometryReader { geometry in
             let callViewSize = callViewSize(geometry: geometry)
 

--- a/Examples/Conference/App/Shared/Screens/Conference/ConferenceViewModel.swift
+++ b/Examples/Conference/App/Shared/Screens/Conference/ConferenceViewModel.swift
@@ -390,6 +390,7 @@ private extension ConferenceViewModel {
             }
             .store(in: &cancellables)
     }
+    // swiftlint:enable cyclomatic_complexity
 }
 
 // MARK: - Private

--- a/Examples/Conference/App/Shared/Screens/PinChallenge/PinChallengeView.swift
+++ b/Examples/Conference/App/Shared/Screens/PinChallenge/PinChallengeView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,8 +29,7 @@ struct PinChallengeView: View {
         }
     }
 
-    @ViewBuilder
-    private var pinInput: some View {
+    @ViewBuilder private var pinInput: some View {
         Text("Welcome to the meeting, \(viewModel.displayName)!")
             .font(.title)
 

--- a/Examples/VideoFilters/VideoFiltersExample/Camera/CameraViewModel.swift
+++ b/Examples/VideoFilters/VideoFiltersExample/Camera/CameraViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -109,6 +109,7 @@ final class CameraViewModel: ObservableObject {
             )
         }
     }
+    // swiftlint:enable cyclomatic_complexity function_body_length
 
     private func segmenter(
         for segmentationSettings: Settings.Segmentation

--- a/Examples/VideoFilters/VideoFiltersExample/Camera/MLKitPersonSegmenter.swift
+++ b/Examples/VideoFilters/VideoFiltersExample/Camera/MLKitPersonSegmenter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -98,6 +98,7 @@ final class MLKitPersonSegmenter: PersonSegmenter {
         {
             deviceOrientation = currentOrientation
         }
+        // swiftlint:enable opening_brace
 
         switch deviceOrientation {
         case .portrait:

--- a/Package.swift
+++ b/Package.swift
@@ -79,9 +79,6 @@ let package = Package(
             dependencies: [
                 "PexipMedia",
                 .product(name: "WebRTC", package: "webrtc-objc")
-            ],
-            cSettings: [
-               .unsafeFlags(["-w"])
             ]
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ media signaling technologies in the future, or Infinity might be interchanged wi
 - Swift 5.5 with structured concurrency support
 - Xcode 13
 
+:warning: **The project doesn't compile on Xcode 14.3 because of incorrect availability attributes CGDisplayStream.h file (introduced: is 13.0 instead of 10.8). Let's hope it's fixed in future Xcode versions.**
+
 ## Installation
 
 ### Swift Package Manager

--- a/Sources/PexipInfinityClient/Conference/Conference.swift
+++ b/Sources/PexipInfinityClient/Conference/Conference.swift
@@ -258,6 +258,8 @@ final class DefaultConference: Conference {
             notify(outputEvent)
         }
     }
+    // swiftlint:enable cyclomatic_complexity
+    // swiftlint:enable function_body_length
 
     @MainActor
     private func notify(_ event: ConferenceClientEvent) {

--- a/Sources/PexipInfinityClient/Conference/ConferenceService.swift
+++ b/Sources/PexipInfinityClient/Conference/ConferenceService.swift
@@ -235,3 +235,4 @@ struct DefaultConferenceService: ConferenceService {
         }
     }
 }
+// swiftlint:enable line_length

--- a/Sources/PexipInfinityClient/Conference/ConferenceToken.swift
+++ b/Sources/PexipInfinityClient/Conference/ConferenceToken.swift
@@ -50,6 +50,7 @@ public struct ConferenceToken: InfinityToken, Codable, Hashable {
         case _analyticsEnabled = "analytics_enabled"
         case _directMedia = "direct_media"
     }
+    // swiftlint:enable identifier_name
 
     /// A textual representation of this type, suitable for debugging.
     public static let name = "Conference token"

--- a/Sources/PexipInfinityClient/Conference/Internal/ConferenceEventParser.swift
+++ b/Sources/PexipInfinityClient/Conference/Internal/ConferenceEventParser.swift
@@ -99,4 +99,5 @@ struct ConferenceEventParser: InfinityEventParser {
             return .clientDisconnected(event)
         }
     }
+    // swiftlint:enable cyclomatic_complexity
 }

--- a/Sources/PexipInfinityClient/InfinityService.swift
+++ b/Sources/PexipInfinityClient/InfinityService.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ public extension InfinityService {
                 return url
             }
         }
+        // swiftlint: enable for_where
 
         return nil
     }

--- a/Sources/PexipInfinityClient/Node/Internal/DNSLookupClient.swift
+++ b/Sources/PexipInfinityClient/Node/Internal/DNSLookupClient.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -122,6 +122,7 @@ final class DNSLookupClient: DNSLookupClientProtocol {
             context.records.append(Data(bytes: bytes, count: Int(length)))
         }
     }
+    // swiftlint:enable closure_parameter_position
 }
 
 // MARK: - Private extensions

--- a/Sources/PexipInfinityClient/Node/NodeService.swift
+++ b/Sources/PexipInfinityClient/Node/NodeService.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -106,3 +106,4 @@ struct DefaultNodeService: NodeService {
         )
     }
 }
+// swiftlint:enable line_length

--- a/Sources/PexipInfinityClient/Participants/Participant.swift
+++ b/Sources/PexipInfinityClient/Participants/Participant.swift
@@ -241,3 +241,4 @@ public struct Participant: Codable, Hashable, Identifiable {
         case deny = "DENY"
     }
 }
+// swiftlint:enable identifier_name

--- a/Sources/PexipRTC/Internal/WebRTCMediaConnection.swift
+++ b/Sources/PexipRTC/Internal/WebRTCMediaConnection.swift
@@ -594,3 +594,4 @@ extension WebRTCMediaConnection: RTCDataChannelDelegate {
         }
     }
 }
+// swiftlint:enable file_length

--- a/Sources/PexipScreenCapture/iOS/Internal/BroadcastNotificationCenter.swift
+++ b/Sources/PexipScreenCapture/iOS/Internal/BroadcastNotificationCenter.swift
@@ -67,6 +67,7 @@ final class BroadcastNotificationCenter {
                 observation.handler()
             }
         }
+        // swiftlint:enable prefer_self_in_static_references
 
         CFNotificationCenterAddObserver(
             center,

--- a/Sources/PexipScreenCapture/macOS/Internal/New/NewScreenMediaCapturer.swift
+++ b/Sources/PexipScreenCapture/macOS/Internal/New/NewScreenMediaCapturer.swift
@@ -29,10 +29,9 @@ import ScreenCaptureKit
  */
 @available(macOS 12.3, *)
 final class NewScreenMediaCapturer<Factory: ScreenCaptureStreamFactory>: NSObject,
-    ScreenMediaCapturer,
-    SCStreamOutput,
-    SCStreamDelegate
-{
+                                                                         ScreenMediaCapturer,
+                                                                         SCStreamOutput,
+                                                                         SCStreamDelegate {
     let source: ScreenMediaSource
     weak var delegate: ScreenMediaCapturerDelegate?
     private(set) var isCapturing = false
@@ -121,6 +120,7 @@ final class NewScreenMediaCapturer<Factory: ScreenCaptureStreamFactory>: NSObjec
         else {
             return
         }
+        // swiftlint:enable force_cast
 
         let transform = CGAffineTransform(scaleX: scaleFactor, y: scaleFactor)
         contentRect = contentRect.applying(transform)

--- a/Sources/PexipScreenCapture/macOS/Internal/New/ScreenCaptureKit+Extensions.swift
+++ b/Sources/PexipScreenCapture/macOS/Internal/New/ScreenCaptureKit+Extensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import ScreenCaptureKit
 // MARK: - ShareableContent
 
 // swiftlint:disable type_name
+
 @available(macOS 12.3, *)
 protocol ShareableContent {
     associatedtype Content: ShareableContent
@@ -91,5 +92,7 @@ extension SCDisplay: Display {}
 
 @available(macOS 12.3, *)
 extension SCRunningApplication: RunningApplication {}
+
+// swiftlint:enable type_name
 
 #endif

--- a/Tests/PexipInfinityClientTests/Conference/ConferenceServiceTests.swift
+++ b/Tests/PexipInfinityClientTests/Conference/ConferenceServiceTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,8 +52,13 @@ final class ConferenceServiceTests: APITestCase {
             responseJSON: responseJSON,
             assertHTTPErrors: false,
             execute: { [weak self] in
-                var token = try await service.requestToken(fields: fields, pin: pin)
-                XCTAssertEqual(self?.lastRequest?.value(forHTTPHeaderField: "pin"), pin)
+                guard let self else {
+                    XCTFail("Test case was deallocated")
+                    return
+                }
+
+                var token = try await self.service.requestToken(fields: fields, pin: pin)
+                XCTAssertEqual(self.lastRequest?.value(forHTTPHeaderField: "pin"), pin)
                 XCTAssertEqual(token.value, expectedToken.value)
                 XCTAssertEqual(token.expires, expectedToken.expires)
                 // Update token to have the same `updatedAt` date as in expected token
@@ -82,12 +87,17 @@ final class ConferenceServiceTests: APITestCase {
             responseJSON: responseJSON,
             assertHTTPErrors: false,
             execute: { [weak self] in
-                var token = try await service.requestToken(
+                guard let self else {
+                    XCTFail("Test case was deallocated")
+                    return
+                }
+
+                var token = try await self.service.requestToken(
                     fields: fields,
                     incomingToken: incomingToken
                 )
                 XCTAssertEqual(
-                    self?.lastRequest?.value(forHTTPHeaderField: "token"),
+                    self.lastRequest?.value(forHTTPHeaderField: "token"),
                     incomingToken
                 )
                 XCTAssertEqual(token.value, expectedToken.value)
@@ -366,6 +376,7 @@ final class ConferenceServiceTests: APITestCase {
         )
     }
 }
+// swiftlint:enable type_body_length
 
 // MARK: - Private types
 

--- a/Tests/PexipInfinityClientTests/Conference/ConferenceTests.swift
+++ b/Tests/PexipInfinityClientTests/Conference/ConferenceTests.swift
@@ -19,8 +19,7 @@ import PexipCore
 import TestHelpers
 @testable import PexipInfinityClient
 
-// swiftlint:disable file_length
-// swiftlint:disable type_body_length
+// swiftlint:disable file_length type_body_length function_body_length
 final class ConferenceTests: XCTestCase {
     private var conference: DefaultConference!
     private var tokenStore: TokenStore<ConferenceToken>!
@@ -39,7 +38,6 @@ final class ConferenceTests: XCTestCase {
 
     // MARK: - Setup
 
-    // swiftlint:disable function_body_length
     override func setUp() async throws {
         try await super.setUp()
 
@@ -764,6 +762,7 @@ final class ConferenceTests: XCTestCase {
         wait(for: [assertExpectation], timeout: 0.1)
     }
 }
+// swiftlint:enable type_body_length
 
 // MARK: - Mocks
 
@@ -869,3 +868,5 @@ private extension ConferenceStatus {
         )
     }
 }
+// swiftlint:enable function_body_length
+// swiftlint:enable file_length

--- a/Tests/PexipInfinityClientTests/Conference/ConferenceTokenTests.swift
+++ b/Tests/PexipInfinityClientTests/Conference/ConferenceTokenTests.swift
@@ -108,6 +108,7 @@ final class ConferenceTokenTests: XCTestCase {
             )
         )
     }
+    // swiftlint:enable function_body_length
 
     func testUpdating() throws {
         let date = Date()

--- a/Tests/PexipInfinityClientTests/Conference/Internal/ConferenceSignalingChannelTests.swift
+++ b/Tests/PexipInfinityClientTests/Conference/Internal/ConferenceSignalingChannelTests.swift
@@ -469,12 +469,12 @@ final class ConferenceSignalingChannelTests: XCTestCase {
         )
     }
 }
+// swiftlint:enable type_body_length
 
 // MARK: - Mocks
 
 // swiftlint:disable unavailable_function
 // swiftlint:disable fatal_error_message
-
 private final class ParticipantServiceMock: ParticipantService {
     enum Action {
         case calls
@@ -581,3 +581,6 @@ private final class CallServiceMock: CallService {
         return try XCTUnwrap(results[action]?.get() as? T)
     }
 }
+// swiftlint:enable unavailable_function
+// swiftlint:enable fatal_error_message
+// swiftlint:enable file_length

--- a/Tests/PexipInfinityClientTests/Conference/RosterTests.swift
+++ b/Tests/PexipInfinityClientTests/Conference/RosterTests.swift
@@ -383,6 +383,7 @@ final class RosterTests: XCTestCase {
         XCTAssertEqual(publishCount, 3)
     }
 }
+// swiftlint:enable type_body_length
 
 // MARK: - Mocks
 

--- a/Tests/PexipInfinityClientTests/InfinityClientFactoryTests.swift
+++ b/Tests/PexipInfinityClientTests/InfinityClientFactoryTests.swift
@@ -310,7 +310,6 @@ private final class ConferenceServiceMock: ConferenceService {
     }
 }
 
-// swiftlint:disable unavailable_function
 private struct ParticipantServiceMock: ParticipantService {
     let id: String
 
@@ -365,6 +364,7 @@ private struct ParticipantServiceMock: ParticipantService {
         fatalError("Not implemented")
     }
 }
+// swiftlint:enable unavailable_function
 
 private final class DataSenderMock: DataSender {
     private(set) var data: Data?

--- a/Tests/PexipInfinityClientTests/InfinityServiceTests.swift
+++ b/Tests/PexipInfinityClientTests/InfinityServiceTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -109,3 +109,4 @@ private struct NodeServiceMock: NodeService {
         fatalError("Not implemented")
     }
 }
+// swiftlint:enable unavailable_function

--- a/Tests/PexipInfinityClientTests/Participants/ParticipantTests.swift
+++ b/Tests/PexipInfinityClientTests/Participants/ParticipantTests.swift
@@ -16,8 +16,8 @@
 import XCTest
 @testable import PexipInfinityClient
 
+// swiftlint:disable function_body_length
 final class ParticipantTests: XCTestCase {
-    // swiftlint:disable function_body_length
     func testDecoding() throws {
         let id = "50b956c8-9a63-4711-8630-3810f8666b04"
         let json = """
@@ -201,3 +201,4 @@ final class ParticipantTests: XCTestCase {
         XCTAssertFalse(participant.isTransferSupported)
     }
 }
+// swiftlint:enable function_body_length

--- a/Tests/PexipInfinityClientTests/Registration/RegistrationServiceTests.swift
+++ b/Tests/PexipInfinityClientTests/Registration/RegistrationServiceTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -44,12 +44,17 @@ final class RegistrationServiceTests: APITestCase {
             responseJSON: responseJSON,
             assertHTTPErrors: false,
             execute: { [weak self] in
+                guard let self else {
+                    XCTFail("Test case was deallocated")
+                    return
+                }
+
                 var token = try await service.requestToken(
                     username: username,
                     password: password
                 )
                 XCTAssertEqual(
-                    self?.lastRequest?.value(forHTTPHeaderField: "Authorization"),
+                    self.lastRequest?.value(forHTTPHeaderField: "Authorization"),
                     HTTPHeader.authorization(username: username, password: password).value
                 )
                 XCTAssertEqual(token.value, expectedToken.value)

--- a/Tests/PexipInfinityClientTests/TestHelpers/APITestCase.swift
+++ b/Tests/PexipInfinityClientTests/TestHelpers/APITestCase.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -105,6 +105,7 @@ class APITestCase: XCTestCase {
             assertRequest(withMethod: method, url: url, token: token, jsonBody: body)
         }
     }
+    // swiftlint:enable function_parameter_count
 
     func assertRequest(
         withMethod method: HTTPMethod,
@@ -154,3 +155,4 @@ class APITestCase: XCTestCase {
         }
     }
 }
+// swiftlint:enable test_case_accessibility

--- a/Tests/PexipInfinityClientTests/Token/Internal/TokenRefreshTaskTests.swift
+++ b/Tests/PexipInfinityClientTests/Token/Internal/TokenRefreshTaskTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ final class TokenRefreshTaskTests: XCTestCase {
 
     // MARK: - Setup
 
-    // swiftlint:disable unowned_variable_capture
     override func setUpWithError() throws {
         try super.setUpWithError()
 
@@ -48,8 +47,8 @@ final class TokenRefreshTaskTests: XCTestCase {
         )
         store = TokenStore(
             token: .randomToken(),
-            currentDateProvider: { [unowned self] in
-                self.currentDate
+            currentDateProvider: { [weak self] in
+                self?.currentDate ?? Date()
             }
         )
         service = TokenServiceMock()
@@ -368,12 +367,13 @@ final class TokenRefreshTaskTests: XCTestCase {
         DefaultTokenRefreshTask(
             store: store,
             service: service,
-            currentDate: { [unowned self] in
-                self.currentDate
+            currentDate: { [weak self] in
+                self?.currentDate ?? Date()
             }
         )
     }
 }
+// swiftlint:enable type_body_length
 
 // MARK: - Mocks
 
@@ -404,3 +404,4 @@ private final class TokenServiceMock: TokenService {
         try releaseTokenResult.get()
     }
 }
+// swiftlint:enable file_length

--- a/Tests/PexipScreenCaptureTests/iOS/BroadcastSampleHandlerTests.swift
+++ b/Tests/PexipScreenCaptureTests/iOS/BroadcastSampleHandlerTests.swift
@@ -371,6 +371,7 @@ final class BroadcastSampleHandlerTests: XCTestCase {
         notificationCenter.post(.receiverStarted)
     }
 }
+// swiftlint:enable type_body_length
 
 // MARK: - Mocks
 

--- a/Tests/PexipScreenCaptureTests/iOS/BroadcastScreenCapturerTests.swift
+++ b/Tests/PexipScreenCaptureTests/iOS/BroadcastScreenCapturerTests.swift
@@ -349,6 +349,7 @@ final class BroadcastScreenCapturerTests: XCTestCase {
 
         XCTAssertEqual(states, [.started, .newFrame, .stopped])
     }
+    // swiftlint:enable function_body_length
 
     func testDeinit() {
         startReceiver()
@@ -370,5 +371,6 @@ final class BroadcastScreenCapturerTests: XCTestCase {
         wait(for: [expectation], timeout: 0.1)
     }
 }
+// swiftlint:enable type_body_length
 
 #endif

--- a/Tests/PexipScreenCaptureTests/macOS/Internal/New/NewScreenMediaCapturerTests.swift
+++ b/Tests/PexipScreenCaptureTests/macOS/Internal/New/NewScreenMediaCapturerTests.swift
@@ -613,6 +613,10 @@ final class StreamMock: SCStream {
 
         return sampleBuffer!
     }
+    // swiftlint:enable function_body_length
 }
 
 #endif
+
+// swiftlint:enable type_body_length
+// swiftlint:enable file_length

--- a/Tests/PexipVideoFiltersTests/Internal/ImageFilterTests.swift
+++ b/Tests/PexipVideoFiltersTests/Internal/ImageFilterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Tests/PexipVideoFiltersTests/Internal/ImageFilterTests.swift
+++ b/Tests/PexipVideoFiltersTests/Internal/ImageFilterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Fix new warnings after updating SwiftLint to 0.51.0
- Fix some of the Xcode 14.3 warnings

The project doesn't build for Mac on Xcode 14.3 due to incorrect availability attributes CGDisplayStream.h file (introduced: is 13.0 instead of 10.8). Added a note about this in README.  Let's hope it's fixed in future Xcode versions, otherwise we'll have to bump macOS target to 13.0, which also defeats the purpose of using `CGDisplayStream`. 