### PR TITLE
Use default bundle policy

### DIFF
--- a/Docs/pexip-swift-sdk-docs/Sources/PexipSwiftSDK/PexipSwiftSDK.docc/Articles/Installation.md
+++ b/Docs/pexip-swift-sdk-docs/Sources/PexipSwiftSDK/PexipSwiftSDK.docc/Articles/Installation.md
@@ -8,7 +8,7 @@ Integrate Pexip Swift SDK into your project using Swift Package Manager, CocoaPo
 - macOS 10.15+
 - Swift 5.5 with structured concurrency support
 - Xcode 13
-- Pexip Infinity v29 and higher.
+- Pexip Infinity v29 and higher
 
 ## Swift Package Manager
 

--- a/Docs/pexip-swift-sdk-docs/Sources/PexipSwiftSDK/PexipSwiftSDK.docc/Articles/Installation.md
+++ b/Docs/pexip-swift-sdk-docs/Sources/PexipSwiftSDK/PexipSwiftSDK.docc/Articles/Installation.md
@@ -8,6 +8,7 @@ Integrate Pexip Swift SDK into your project using Swift Package Manager, CocoaPo
 - macOS 10.15+
 - Swift 5.5 with structured concurrency support
 - Xcode 13
+- Pexip Infinity v29 and higher.
 
 ## Swift Package Manager
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ media signaling technologies in the future, or Infinity might be interchanged wi
 - macOS 10.15+
 - Swift 5.5 with structured concurrency support
 - Xcode 13
-- Pexip Infinity v29 and higher.
+- Pexip Infinity v29 and higher
 
 :warning: **The project doesn't compile on Xcode 14.3 because of incorrect availability attributes CGDisplayStream.h file (introduced: is 13.0 instead of 10.8). Let's hope it's fixed in future Xcode versions.**
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ media signaling technologies in the future, or Infinity might be interchanged wi
 - macOS 10.15+
 - Swift 5.5 with structured concurrency support
 - Xcode 13
+- Pexip Infinity v29 and higher.
 
 :warning: **The project doesn't compile on Xcode 14.3 because of incorrect availability attributes CGDisplayStream.h file (introduced: is 13.0 instead of 10.8). Let's hope it's fixed in future Xcode versions.**
 

--- a/Sources/PexipInfinityClient/Conference/ConferenceService.swift
+++ b/Sources/PexipInfinityClient/Conference/ConferenceService.swift
@@ -196,7 +196,23 @@ struct DefaultConferenceService: ConferenceService {
 
             switch response.statusCode {
             case 200:
-                return try parse200(from: data)
+                let token = try parse200(from: data)
+                if let version = Double(token.version.versionId), version < 29 {
+                    logger?.warn(
+                        """
+
+                        WARNING: Infinity v\(version) support.
+
+                        We offer only limited support for Infinity versions prior to v29.
+                        You may experience problems with sending and receiving presentation.
+                        Use `presentationInMain` to mix presentation with main video feed.
+
+                        This will be a fatar error in Q4 2023.
+                        """
+                    )
+                }
+                return token
+
             case 401:
                 // Bad HTTP credentials
                 throw HTTPError.unauthorized

--- a/Sources/PexipInfinityClient/Conference/ConferenceService.swift
+++ b/Sources/PexipInfinityClient/Conference/ConferenceService.swift
@@ -212,7 +212,6 @@ struct DefaultConferenceService: ConferenceService {
                     )
                 }
                 return token
-
             case 401:
                 // Bad HTTP credentials
                 throw HTTPError.unauthorized

--- a/Sources/PexipRTC/Internal/Extensions/RTCConfiguration+Default.swift
+++ b/Sources/PexipRTC/Internal/Extensions/RTCConfiguration+Default.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ extension RTCConfiguration {
                 credential: $0.password
             )
         }
-        configuration.bundlePolicy = .maxBundle
+        configuration.bundlePolicy = .balanced
         configuration.sdpSemantics = .unifiedPlan
         configuration.enableDscp = dscp
         configuration.continualGatheringPolicy = .gatherContinually


### PR DESCRIPTION
- Use default bundle policy
- Print a warning if Infinity version prior to v29 is detected. This is just a console warning, since there is no official way of throwing runtime warnings in Xcode.