### PR TITLE
fix(PexipScreenCapture): filter out windows without bundle ID

### DIFF
--- a/Sources/PexipScreenCapture/macOS/ScreenMediaSourceEnumerator.swift
+++ b/Sources/PexipScreenCapture/macOS/ScreenMediaSourceEnumerator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ public extension ScreenMediaSourceEnumerator {
                 && $0.title?.isEmpty == false
                 && $0.application != nil
                 && $0.application?.bundleIdentifier != Bundle.main.bundleIdentifier
+                && $0.application?.bundleIdentifier.isEmpty == false
         }
     }
 }


### PR DESCRIPTION
Cover an edge case when bundleIdentifier is an empty string for some status activity indicators that for some reason are being returned as windows by `ScreenCaptureKit` 🙂 