### PR TITLE
refactor(PexipInfinityClient): rename ConferenceAlias and DeviceAlias

### DIFF
--- a/Examples/Conference/App/Shared/App/Screen.swift
+++ b/Examples/Conference/App/Shared/App/Screen.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ enum Screen: Equatable, Hashable {
     case displayName
     case alias
     case pinChallenge(
-        alias: ConferenceAlias,
+        alias: String,
         node: URL,
         tokenError: ConferenceTokenError
     )

--- a/Examples/Conference/App/Shared/App/ViewFactory.swift
+++ b/Examples/Conference/App/Shared/App/ViewFactory.swift
@@ -43,7 +43,7 @@ struct ViewFactory {
 
     func pinChallengeView(
         node: URL,
-        alias: ConferenceAlias,
+        alias: String,
         tokenError: ConferenceTokenError,
         onComplete: @escaping PinChallengeViewModel.Complete
     ) -> PinChallengeView {

--- a/Examples/Conference/App/Shared/Screens/Conference/ConferenceConnector.swift
+++ b/Examples/Conference/App/Shared/Screens/Conference/ConferenceConnector.swift
@@ -40,14 +40,14 @@ final class ConferenceConnector {
     func join(
         using method: RequestMethod,
         displayName: String,
-        conferenceAlias: String
+        conferenceAddress: String
     ) async throws -> ConferenceDetails {
-        guard let alias = ConferenceAlias(uri: conferenceAlias) else {
+        guard let address = ConferenceAddress(uri: conferenceAddress) else {
             throw NodeError.invalidConferenceAlias
         }
 
-        let node = try await resolveNode(forHost: alias.host)
-        let conferenceService = service.node(url: node).conference(alias: alias)
+        let node = try await resolveNode(forHost: address.host)
+        let conferenceService = service.node(url: node).conference(alias: address.alias)
         let fields = ConferenceTokenRequestFields(displayName: displayName)
         let token: ConferenceToken
 
@@ -64,7 +64,7 @@ final class ConferenceConnector {
             )
         }
 
-        return ConferenceDetails(node: node, alias: alias, token: token)
+        return ConferenceDetails(node: node, alias: address.alias, token: token)
     }
 
     // MARK: - Private

--- a/Examples/Conference/App/Shared/Screens/Conference/ConferenceDetails.swift
+++ b/Examples/Conference/App/Shared/Screens/Conference/ConferenceDetails.swift
@@ -19,6 +19,6 @@ import PexipInfinityClient
 struct ConferenceDetails: Identifiable, Hashable {
     let id = UUID()
     let node: URL
-    let alias: ConferenceAlias
+    let alias: String
     let token: ConferenceToken
 }

--- a/Examples/Conference/App/Shared/Screens/Conference/ConferenceView.swift
+++ b/Examples/Conference/App/Shared/Screens/Conference/ConferenceView.swift
@@ -253,7 +253,7 @@ struct ConferenceView: View {
 struct ConferenceView_Previews: PreviewProvider {
     private static let conference = InfinityClientFactory().conference(
         node: URL(string: "https://test.com")!,
-        alias: ConferenceAlias(uri: "test@example.com")!,
+        alias: "test",
         token: ConferenceToken(
             value: "test",
             participantId: UUID().uuidString,

--- a/Examples/Conference/App/Shared/Screens/Conference/ConferenceViewModel.swift
+++ b/Examples/Conference/App/Shared/Screens/Conference/ConferenceViewModel.swift
@@ -473,7 +473,7 @@ private extension ConferenceViewModel {
                 let details = try await conferenceConnector.join(
                     using: .incomingToken(event.token),
                     displayName: displayName,
-                    conferenceAlias: event.alias
+                    conferenceAddress: event.alias
                 )
                 onComplete(.transfer(details))
             } catch {

--- a/Examples/Conference/App/Shared/Screens/PinChallenge/PinChallengeView.swift
+++ b/Examples/Conference/App/Shared/Screens/PinChallenge/PinChallengeView.swift
@@ -59,7 +59,7 @@ struct PinChallengeView_Previews: PreviewProvider {
                 service: InfinityClientFactory()
                     .infinityService()
                     .node(url: URL(string: "https://test.example.com")!)
-                    .conference(alias: ConferenceAlias(uri: "test@example.com")!),
+                    .conference(alias: "test"),
                 onComplete: { _ in }
             )
         )

--- a/Examples/Conference/App/macOS/IncomingCall/IncomingCallViewModel.swift
+++ b/Examples/Conference/App/macOS/IncomingCall/IncomingCallViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,9 +60,9 @@ final class IncomingCallViewModel: ObservableObject {
     @MainActor
     func accept() async {
         guard
-            let alias = ConferenceAlias(uri: details.conferenceAlias),
+            let address = ConferenceAddress(uri: details.conferenceAlias),
             let nodeURL = try? await service.resolveNodeURL(
-                forHost: alias.host,
+                forHost: address.host,
                 using: nodeResolver
             )
         else {
@@ -74,9 +74,9 @@ final class IncomingCallViewModel: ObservableObject {
             let displayName = self.displayName
             let fields = ConferenceTokenRequestFields(displayName: displayName)
             let token = try await service.node(url: nodeURL)
-                .conference(alias: alias)
+                .conference(alias: address.alias)
                 .requestToken(fields: fields, incomingToken: details.token)
-            onAccept(IncomingCall(node: nodeURL, alias: alias, token: token))
+            onAccept(IncomingCall(node: nodeURL, alias: address.alias, token: token))
         } catch {
             debugPrint(error)
             decline(withMessage: "Cannot join the call. Invalid token.")

--- a/Examples/Conference/App/macOS/Registration/RegistrationService.swift
+++ b/Examples/Conference/App/macOS/Registration/RegistrationService.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ final class RegistrationService {
         username: String,
         password: String
     ) async throws {
-        guard let deviceAlias = DeviceAlias(uri: deviceAlias) else {
+        guard let deviceAddress = DeviceAddress(uri: deviceAlias) else {
             throw RegistrationError.invalidDeviceAlias
         }
 
@@ -62,14 +62,14 @@ final class RegistrationService {
         let nodeResolver = InfinityClientFactory().nodeResolver(dnssec: false)
 
         guard let nodeURL = try await service.resolveNodeURL(
-            forHost: deviceAlias.host,
+            forHost: deviceAddress.host,
             using: nodeResolver
         ) else {
             throw RegistrationError.invalidDeviceAlias
         }
 
         let token = try await service.node(url: nodeURL)
-            .registration(deviceAlias: deviceAlias)
+            .registration(deviceAlias: deviceAddress.alias)
             .requestToken(username: username, password: password)
 
         registration = factory.registration(
@@ -80,7 +80,7 @@ final class RegistrationService {
         registration?.delegate = self
         registration?.receiveEvents()
 
-        userDefaults[string: .deviceAlias] = deviceAlias.uri
+        userDefaults[string: .deviceAlias] = deviceAlias
         keychain[string: .username] = username
         keychain[string: .password] = password
     }

--- a/Examples/Conference/App/macOS/Registration/RegistrationViewModel.swift
+++ b/Examples/Conference/App/macOS/Registration/RegistrationViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ final class RegistrationViewModel: ObservableObject {
     private let service: RegistrationService
 
     var isValid: Bool {
-        DeviceAlias(uri: alias) != nil && !username.isEmpty && !password.isEmpty
+        DeviceAddress(uri: alias) != nil && !username.isEmpty && !password.isEmpty
     }
 
     // MARK: - Init

--- a/Sources/PexipInfinityClient/Conference/ConferenceAddress.swift
+++ b/Sources/PexipInfinityClient/Conference/ConferenceAddress.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,9 +15,11 @@
 
 import Foundation
 
-/// An alias of the conference you are connecting to.
-public struct ConferenceAlias: Hashable {
-    public let uri: String
+@available(*, deprecated, renamed: "ConferenceAddress")
+public typealias ConferenceAlias = ConferenceAddress
+
+/// An address of the conference you are connecting to.
+public struct ConferenceAddress: Hashable {
     public let alias: String
     public let host: String
 
@@ -31,16 +33,6 @@ public struct ConferenceAlias: Hashable {
             return nil
         }
 
-        self.init(alias: alias, host: host)
-    }
-
-    /**
-     - Parameters:
-        - alias: Conference or device alias
-        - host: Conference host in the form of "example.com"
-     */
-    public init?(alias: String, host: String) {
-        let uri = "\(alias)@\(host)"
         let checkingType = NSTextCheckingResult.CheckingType.link.rawValue
         let detector = try? NSDataDetector(types: checkingType)
         let range = NSRange(uri.startIndex..<uri.endIndex, in: uri)
@@ -55,7 +47,15 @@ public struct ConferenceAlias: Hashable {
             return nil
         }
 
-        self.uri = uri
+        self.init(alias: alias, host: host)
+    }
+
+    /**
+     - Parameters:
+        - alias: Conference or device alias
+        - host: Conference host in the form of "example.com"
+     */
+    public init(alias: String, host: String) {
         self.alias = alias
         self.host = host
     }

--- a/Sources/PexipInfinityClient/InfinityClientFactory.swift
+++ b/Sources/PexipInfinityClient/InfinityClientFactory.swift
@@ -83,9 +83,28 @@ public struct InfinityClientFactory {
 
      - Returns: A new instance of ``Registration``.
      */
+    @available(*, deprecated, message: "Use String based registration(node:deviceAlias:token) instead.")
     public func registration(
         node: URL,
-        deviceAlias: DeviceAlias,
+        deviceAlias: DeviceAddress,
+        token: RegistrationToken
+    ) -> Registration {
+        registration(node: node, deviceAlias: deviceAlias.alias, token: token)
+    }
+
+    /**
+     Creates a new instance of ``Registration`` type.
+
+     - Parameters:
+        - node: A conferencing node address in the form of https://example.com
+        - deviceAlias: A device alias
+        - token: A registration token
+
+     - Returns: A new instance of ``Registration``.
+     */
+    public func registration(
+        node: URL,
+        deviceAlias: String,
         token: RegistrationToken
     ) -> Registration {
         let nodeService = infinityService().node(url: node)
@@ -109,6 +128,25 @@ public struct InfinityClientFactory {
         )
     }
 
+    /**
+     Creates a new instance of ``Conference`` type.
+
+     - Parameters:
+        - node: A conferencing node address in the form of https://example.com
+        - alias: A conference alias
+        - token: A token of the conference
+
+     - Returns: A new instance of ``Conference``.
+     */
+    @available(*, deprecated, message: "Use String based conference(node:alias:token) instead.")
+    public func conference(
+        node: URL,
+        alias: ConferenceAddress,
+        token: ConferenceToken
+    ) -> Conference {
+        conference(node: node, alias: alias.alias, token: token)
+    }
+
     // swiftlint:disable function_body_length
     /**
      Creates a new instance of ``Conference`` type.
@@ -122,7 +160,7 @@ public struct InfinityClientFactory {
      */
     public func conference(
         node: URL,
-        alias: ConferenceAlias,
+        alias: String,
         token: ConferenceToken
     ) -> Conference {
         if token.version.versionId < "29" {

--- a/Sources/PexipInfinityClient/Node/NodeService.swift
+++ b/Sources/PexipInfinityClient/Node/NodeService.swift
@@ -45,7 +45,17 @@ public protocol NodeService {
         - alias: A conference alias
      - Returns: A conference service for the given alias.
      */
-    func conference(alias: ConferenceAlias) -> ConferenceService
+    @available(*, deprecated, message: "Use String based conference(alias:) instead.")
+    func conference(alias: ConferenceAddress) -> ConferenceService
+
+    /**
+     Sets the conference alias.
+
+     - Parameters:
+        - alias: A conference alias
+     - Returns: A conference service for the given alias.
+     */
+    func conference(alias: String) -> ConferenceService
 
     /**
      Sets the registration alias.
@@ -54,7 +64,17 @@ public protocol NodeService {
         - alias: A device alias
      - Returns: A registration service for the given alias.
      */
-    func registration(deviceAlias: DeviceAlias) -> RegistrationService
+    @available(*, deprecated, message: "Use String based registration(deviceAlias:) instead.")
+    func registration(deviceAlias: DeviceAddress) -> RegistrationService
+
+    /**
+     Sets the registration alias.
+
+     - Parameters:
+        - alias: A device alias
+     - Returns: A registration service for the given alias.
+     */
+    func registration(deviceAlias: String) -> RegistrationService
 }
 
 // MARK: - Implementation
@@ -84,22 +104,30 @@ struct DefaultNodeService: NodeService {
         }
     }
 
-    func conference(alias: ConferenceAlias) -> ConferenceService {
-        return DefaultConferenceService(
+    func conference(alias: ConferenceAddress) -> ConferenceService {
+        conference(alias: alias.alias)
+    }
+
+    func conference(alias: String) -> ConferenceService {
+        DefaultConferenceService(
             baseURL: baseURL
                 .appendingPathComponent("conferences")
-                .appendingPathComponent(alias.uri),
+                .appendingPathComponent(alias),
             client: client,
             decoder: decoder,
             logger: logger
         )
     }
 
-    func registration(deviceAlias: DeviceAlias) -> RegistrationService {
-        return DefaultRegistrationService(
+    func registration(deviceAlias: DeviceAddress) -> RegistrationService {
+        registration(deviceAlias: deviceAlias.alias)
+    }
+
+    func registration(deviceAlias: String) -> RegistrationService {
+        DefaultRegistrationService(
             baseURL: baseURL
                 .appendingPathComponent("registrations")
-                .appendingPathComponent(deviceAlias.uri),
+                .appendingPathComponent(deviceAlias),
             client: client,
             decoder: decoder,
             logger: logger

--- a/Sources/PexipInfinityClient/Registration/DeviceAlias.swift
+++ b/Sources/PexipInfinityClient/Registration/DeviceAlias.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,4 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public typealias DeviceAlias = ConferenceAlias
+@available(*, deprecated, renamed: "DeviceAddress")
+public typealias DeviceAlias = ConferenceAddress
+
+public typealias DeviceAddress = ConferenceAddress

--- a/Tests/PexipInfinityClientTests/Conference/ConferenceAddressTests.swift
+++ b/Tests/PexipInfinityClientTests/Conference/ConferenceAddressTests.swift
@@ -1,0 +1,39 @@
+//
+// Copyright 2022-2023 Pexip AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import dnssd
+@testable import PexipInfinityClient
+
+final class ConferenceAddressTests: XCTestCase {
+    func testInitWithURI() throws {
+        XCTAssertNil(ConferenceAddress(uri: ""))
+        XCTAssertNil(ConferenceAddress(uri: "."))
+        XCTAssertNil(ConferenceAddress(uri: "conference"))
+        XCTAssertNil(ConferenceAddress(uri: "@example"))
+        XCTAssertNil(ConferenceAddress(uri: "@example.com"))
+        XCTAssertNil(ConferenceAddress(uri: "conference@example.com conference@example.com"))
+
+        let name = try XCTUnwrap(ConferenceAddress(uri: "conference@example.com"))
+        XCTAssertEqual(name.alias, "conference")
+        XCTAssertEqual(name.host, "example.com")
+    }
+
+    func testInitWithAliasAndHost() throws {
+        let name = ConferenceAddress(alias: "conference", host: "example.com")
+        XCTAssertEqual(name.alias, "conference")
+        XCTAssertEqual(name.host, "example.com")
+    }
+}

--- a/Tests/PexipInfinityClientTests/Conference/ConferenceAliasTests.swift
+++ b/Tests/PexipInfinityClientTests/Conference/ConferenceAliasTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,37 +12,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-import XCTest
-import dnssd
-@testable import PexipInfinityClient
-
-final class ConferenceAliasTests: XCTestCase {
-    func testInitWithURI() throws {
-        XCTAssertNil(ConferenceAlias(uri: ""))
-        XCTAssertNil(ConferenceAlias(uri: "."))
-        XCTAssertNil(ConferenceAlias(uri: "conference"))
-        XCTAssertNil(ConferenceAlias(uri: "@example"))
-        XCTAssertNil(ConferenceAlias(uri: "@example.com"))
-        XCTAssertNil(ConferenceAlias(uri: "conference@example.com conference@example.com"))
-
-        let name = try XCTUnwrap(ConferenceAlias(uri: "conference@example.com"))
-        XCTAssertEqual(name.uri, "conference@example.com")
-        XCTAssertEqual(name.alias, "conference")
-        XCTAssertEqual(name.host, "example.com")
-    }
-
-    func testInitWithAliasAndHost() throws {
-        XCTAssertNil(ConferenceAlias(alias: "", host: ""))
-        XCTAssertNil(ConferenceAlias(alias: ".", host: "."))
-        XCTAssertNil(ConferenceAlias(alias: "conference", host: "example"))
-        XCTAssertNil(ConferenceAlias(alias: "@conference", host: "@example"))
-        XCTAssertNil(ConferenceAlias(alias: "example.com", host: "conference"))
-        XCTAssertNil(ConferenceAlias(alias: "conference", host: "example."))
-
-        let name = try XCTUnwrap(ConferenceAlias(alias: "conference", host: "example.com"))
-        XCTAssertEqual(name.uri, "conference@example.com")
-        XCTAssertEqual(name.alias, "conference")
-        XCTAssertEqual(name.host, "example.com")
-    }
-}

--- a/Tests/PexipInfinityClientTests/InfinityClientFactoryTests.swift
+++ b/Tests/PexipInfinityClientTests/InfinityClientFactoryTests.swift
@@ -40,7 +40,7 @@ final class InfinityClientFactoryTests: XCTestCase {
     func testRegistration() throws {
         let registration = factory.registration(
             node: try XCTUnwrap(URL(string: "https://example.com/conference")),
-            deviceAlias: try XCTUnwrap(DeviceAlias(uri: "device@conference.com")),
+            deviceAlias: "device",
             token: .randomToken()
         )
         XCTAssertTrue(registration is DefaultRegistration)
@@ -49,7 +49,7 @@ final class InfinityClientFactoryTests: XCTestCase {
     func testConference() throws {
         let conference = factory.conference(
             node: try XCTUnwrap(URL(string: "https://example.com/conference")),
-            alias: try XCTUnwrap(ConferenceAlias(uri: "conference@conference.com")),
+            alias: "conference",
             token: .randomToken()
         )
         XCTAssertTrue(conference is DefaultConference)

--- a/Tests/PexipInfinityClientTests/InfinityServiceTests.swift
+++ b/Tests/PexipInfinityClientTests/InfinityServiceTests.swift
@@ -101,11 +101,19 @@ private struct NodeServiceMock: NodeService {
         status
     }
 
-    func conference(alias: ConferenceAlias) -> ConferenceService {
+    func conference(alias: ConferenceAddress) -> ConferenceService {
         fatalError("Not implemented")
     }
 
-    func registration(deviceAlias: DeviceAlias) -> RegistrationService {
+    func conference(alias: String) -> PexipInfinityClient.ConferenceService {
+        fatalError("Not implemented")
+    }
+
+    func registration(deviceAlias: DeviceAddress) -> RegistrationService {
+        fatalError("Not implemented")
+    }
+
+    func registration(deviceAlias: String) -> PexipInfinityClient.RegistrationService {
         fatalError("Not implemented")
     }
 }

--- a/Tests/PexipInfinityClientTests/Node/NodeServiceTests.swift
+++ b/Tests/PexipInfinityClientTests/Node/NodeServiceTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -70,19 +70,19 @@ final class NodeServiceTests: APITestCase {
     }
 
     func testConference() throws {
-        let alias = try XCTUnwrap(DeviceAlias(uri: "name@conference.com"))
+        let alias = "name"
         let service = service.conference(alias: alias) as? DefaultConferenceService
 
         XCTAssertEqual(
             service?.baseURL,
             baseURL
                 .appendingPathComponent("conferences")
-                .appendingPathComponent(alias.uri)
+                .appendingPathComponent(alias)
         )
     }
 
     func testRegistration() throws {
-        let deviceAlias = try XCTUnwrap(DeviceAlias(uri: "device@conference.com"))
+        let deviceAlias = "device"
         let service = service.registration(
             deviceAlias: deviceAlias
         ) as? DefaultRegistrationService
@@ -91,7 +91,7 @@ final class NodeServiceTests: APITestCase {
             service?.baseURL,
             baseURL
                 .appendingPathComponent("registrations")
-                .appendingPathComponent(deviceAlias.uri)
+                .appendingPathComponent(deviceAlias)
         )
     }
 


### PR DESCRIPTION
- Rename `ConferenceAlias` to `ConferenceAddress`
- Rename `DeviceAlias` to `DeviceAddress`
- Make it possible to create `ConferenceAddress` with alias and host and no extra validation
- Add deprecations for methods that accept `ConferenceAlias` and `DeviceAlias`