### PR TITLE
WebRTCMediaConnection: don't set sender stream ids

### DIFF
--- a/Sources/PexipRTC/Internal/Extensions/RTCRtpTransceiver+Extensions.swift
+++ b/Sources/PexipRTC/Internal/Extensions/RTCRtpTransceiver+Extensions.swift
@@ -42,10 +42,6 @@ extension RTCRtpTransceiver {
         }
     }
 
-    func setSenderStreams(_ streams: [RTCMediaStream]) {
-        sender.streamIds = streams.map(\.streamId)
-    }
-
     func send(from track: RTCMediaStreamTrack?) throws {
         try send(track != nil)
         sender.track = track

--- a/Sources/PexipRTC/Internal/WebRTCMediaConnection.swift
+++ b/Sources/PexipRTC/Internal/WebRTCMediaConnection.swift
@@ -644,15 +644,9 @@ extension WebRTCMediaConnection: PeerConnectionDelegate {
         didAdd rtpReceiver: RTCRtpReceiver,
         streams mediaStreams: [RTCMediaStream]
     ) {
-        let track = rtpReceiver.track as? RTCVideoTrack
-
-        if rtpReceiver.receiverId == mainAudioTransceiver?.receiver.receiverId {
-            mainAudioTransceiver?.setSenderStreams(mediaStreams)
-        } else if rtpReceiver.receiverId == mainVideoTransceiver?.receiver.receiverId {
-            mainVideoTransceiver?.setSenderStreams(mediaStreams)
+        if rtpReceiver.receiverId == mainVideoTransceiver?.receiver.receiverId {
+            let track = rtpReceiver.track as? RTCVideoTrack
             remoteVideoTracks.setMainTrack(track.map { WebRTCVideoTrack(rtcTrack: $0) })
-        } else if rtpReceiver.receiverId == presentationVideoTransceiver?.receiver.receiverId {
-            presentationVideoTransceiver?.setSenderStreams(mediaStreams)
         }
     }
 }


### PR DESCRIPTION
This was introduced together with direct media implementation, but seems to cause unnecessary negotiations leading to race conditions.