### PR TITLE
feat(Media): create WebRTCMediaFactory with encoder and decoder

### DIFF
--- a/Sources/PexipRTC/Internal/Extensions/RTCPeerConnectionFactory+Default.swift
+++ b/Sources/PexipRTC/Internal/Extensions/RTCPeerConnectionFactory+Default.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,22 +12,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-import WebRTC
-
-extension RTCPeerConnectionFactory {
-    static func defaultFactory() -> RTCPeerConnectionFactory {
-        RTCInitializeSSL()
-        #if targetEnvironment(simulator) || os(macOS)
-        let videoEncoderFactory = VideoEncoderFactoryVP8()
-        let videoDecoderFactory = VideoDecoderFactoryVP8()
-        #else
-        let videoEncoderFactory = RTCVideoEncoderFactoryH264()
-        let videoDecoderFactory = RTCVideoDecoderFactoryH264()
-        #endif
-        return RTCPeerConnectionFactory(
-            encoderFactory: videoEncoderFactory,
-            decoderFactory: videoDecoderFactory
-        )
-    }
-}

--- a/Sources/PexipRTC/VideoDecoderFactoryVP8.swift
+++ b/Sources/PexipRTC/VideoDecoderFactoryVP8.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
 
 import WebRTC
 
-final class VideoEncoderFactoryVP8: NSObject, RTCVideoEncoderFactory {
-    func createEncoder(_ info: RTCVideoCodecInfo) -> RTCVideoEncoder? {
-        info.name == kRTCVp8CodecName ? RTCVideoEncoderVP8.vp8Encoder() : nil
+public final class VideoDecoderFactoryVP8: NSObject, RTCVideoDecoderFactory {
+    public func createDecoder(_ info: RTCVideoCodecInfo) -> RTCVideoDecoder? {
+        info.name == kRTCVp8CodecName ? RTCVideoDecoderVP8.vp8Decoder() : nil
     }
 
-    func supportedCodecs() -> [RTCVideoCodecInfo] {
+    public func supportedCodecs() -> [RTCVideoCodecInfo] {
         [RTCVideoCodecInfo(name: kRTCVp8CodecName)]
     }
 }

--- a/Sources/PexipRTC/VideoEncoderFactoryVP8.swift
+++ b/Sources/PexipRTC/VideoEncoderFactoryVP8.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2023 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
 
 import WebRTC
 
-final class VideoDecoderFactoryVP8: NSObject, RTCVideoDecoderFactory {
-    func createDecoder(_ info: RTCVideoCodecInfo) -> RTCVideoDecoder? {
-        info.name == kRTCVp8CodecName ? RTCVideoDecoderVP8.vp8Decoder() : nil
+public final class VideoEncoderFactoryVP8: NSObject, RTCVideoEncoderFactory {
+    public func createEncoder(_ info: RTCVideoCodecInfo) -> RTCVideoEncoder? {
+        info.name == kRTCVp8CodecName ? RTCVideoEncoderVP8.vp8Encoder() : nil
     }
 
-    func supportedCodecs() -> [RTCVideoCodecInfo] {
+    public func supportedCodecs() -> [RTCVideoCodecInfo] {
         [RTCVideoCodecInfo(name: kRTCVp8CodecName)]
     }
 }

--- a/Sources/PexipRTC/WebRTCMediaFactory.swift
+++ b/Sources/PexipRTC/WebRTCMediaFactory.swift
@@ -24,8 +24,19 @@ public final class WebRTCMediaFactory: MediaFactory {
 
     // MARK: - Init
 
-    public convenience init(logger: Logger? = DefaultLogger.mediaWebRTC) {
-        self.init(factory: .defaultFactory(), logger: logger)
+    public convenience init(
+        videoEncoderFactory: RTCVideoEncoderFactory = RTCDefaultVideoEncoderFactory(),
+        videoDecoderFactory: RTCVideoDecoderFactory = RTCDefaultVideoDecoderFactory(),
+        logger: Logger? = DefaultLogger.mediaWebRTC
+    ) {
+        RTCInitializeSSL()
+        self.init(
+            factory: RTCPeerConnectionFactory(
+                encoderFactory: videoEncoderFactory,
+                decoderFactory: videoDecoderFactory
+            ),
+            logger: logger
+        )
     }
 
     init(factory: RTCPeerConnectionFactory, logger: Logger? = nil) {


### PR DESCRIPTION
- Make it possible to create `WebRTCMediaFactory` with video encoder and decoder factories
- Use `RTCDefaultVideoEncoderFactory` and `RTCDefaultVideoDecoderFactory` as default factories on all platforms
- `VideoDecoderFactoryVP8` and `VideoEncoderFactoryVP8` are now public in case anyone needs VP8