### PR TITLE
fix(InfinityClient): presentation stop

### DIFF
--- a/Sources/PexipInfinityClient/Conference/Conference.swift
+++ b/Sources/PexipInfinityClient/Conference/Conference.swift
@@ -220,6 +220,7 @@ final class DefaultConference: Conference {
         case .liveCaptions(let event):
             outputEvent = .liveCaptions(event)
         case .presentationStart(let event):
+            skipPresentationStop.setValue(false)
             outputEvent = .presentationStart(event)
         case .presentationStop:
             outputEvent = .presentationStop

--- a/Tests/PexipInfinityClientTests/Conference/ConferenceTests.swift
+++ b/Tests/PexipInfinityClientTests/Conference/ConferenceTests.swift
@@ -160,8 +160,8 @@ final class ConferenceTests: XCTestCase {
             .splashScreen(nil),
             .conferenceUpdate(conferenceStatus),
             .liveCaptions(liveCaptions),
-            .presentationStart(presentationStart),
             .presentationStop, // First presentationStop event should be skipped.
+            .presentationStart(presentationStart),
             .presentationStop,
             .callDisconnected(callDisconnect),
             .clientDisconnected(clientDisconnect),


### PR DESCRIPTION
When joining the conference with ongoing presentation there is no `presentation_stop` event we usually skip, only `presentation_start`.