### PR TITLE
fix(Media): enable re-negotiation when connection started

### DIFF
--- a/Sources/PexipRTC/Internal/PeerConnection/PeerConnection.swift
+++ b/Sources/PexipRTC/Internal/PeerConnection/PeerConnection.swift
@@ -36,7 +36,6 @@ actor PeerConnection {
     private let connectionDelegateProxy: PeerConnectionDelegateProxy
     private let dataChannelDelegateProxy: DataChannelDelegateProxy
     private let logger: Logger?
-    private var shouldRenegotiate = false
     private var transceivers = [MediaContent: Transceiver]()
     private var degradationPreferences = [MediaContent: DegradationPreference]()
     private var bitrate = Bitrate.bps(0)
@@ -94,7 +93,6 @@ actor PeerConnection {
         dataChannel = nil
 
         fingerprintStore.reset()
-        shouldRenegotiate = false
     }
 
     func setLocalDescription() async throws -> RTCSessionDescription? {
@@ -267,15 +265,7 @@ actor PeerConnection {
         guard ![.closed, .disconnected].contains(connection.connectionState) else {
             return
         }
-
-        // Skip the first call to negotiateIfNeeded() since it's
-        // called right after RTCPeerConnection creation,
-        // and we're still not ready for negotiation.
-        if shouldRenegotiate {
-            eventSubject.send(.shouldNegotiate)
-        } else {
-            shouldRenegotiate = true
-        }
+        eventSubject.send(.shouldNegotiate)
     }
 
     private func onReceiver(_ receiver: RTCRtpReceiver, removed: Bool) {

--- a/Sources/PexipRTC/Internal/WebRTCMediaConnection.swift
+++ b/Sources/PexipRTC/Internal/WebRTCMediaConnection.swift
@@ -83,7 +83,6 @@ actor WebRTCMediaConnection: MediaConnection, DataSender {
             return
         }
 
-        started = true
         try await peerConnection.setDirection(.inactive, for: .presentationVideo)
 
         if let dataChannelId = signalingChannel.data?.id {
@@ -98,6 +97,8 @@ actor WebRTCMediaConnection: MediaConnection, DataSender {
         #if os(iOS)
         await AudioSession.shared.activate(for: .call)
         #endif
+
+        started = true
     }
 
     func stop() async {
@@ -238,6 +239,9 @@ actor WebRTCMediaConnection: MediaConnection, DataSender {
         do {
             switch event {
             case .shouldNegotiate:
+                guard started else {
+                    return
+                }
                 try await negotiate {
                     try await $0?.sendOffer()
                 }


### PR DESCRIPTION
Instead of always dropping the first negotiation event, use `started` flag in `WebRTCMediaConnection` to decide whether we should skip re-negotiation or not.