### PR TITLE
fix(InfnityClient): don't check for host on mute/unmute

### DIFF
--- a/Sources/PexipInfinityClient/Conference/Internal/ConferenceSignalingChannel.swift
+++ b/Sources/PexipInfinityClient/Conference/Internal/ConferenceSignalingChannel.swift
@@ -176,10 +176,6 @@ final class ConferenceSignalingChannel: SignalingChannel, SignalingEventSender {
     func muteAudio(_ muted: Bool) async throws -> Bool {
         let token = try await tokenStore.token()
 
-        guard token.role == .host else {
-            return false
-        }
-
         if muted {
             return try await participantService.mute(token: token)
         }

--- a/Tests/PexipInfinityClientTests/Conference/Internal/ConferenceSignalingChannelTests.swift
+++ b/Tests/PexipInfinityClientTests/Conference/Internal/ConferenceSignalingChannelTests.swift
@@ -364,19 +364,6 @@ final class ConferenceSignalingChannelTests: XCTestCase {
         XCTAssertNil(callService.token)
     }
 
-    func testMuteAudioWhenNotHost() async throws {
-        participantService.results[.mute] = .success(true)
-
-        try await tokenStore.updateToken(.randomToken(role: .guest))
-        let result = try await channel.muteAudio(false)
-
-        XCTAssertFalse(result)
-        XCTAssertTrue(participantService.actions.isEmpty)
-        XCTAssertNil(participantService.token)
-        XCTAssertTrue(callService.actions.isEmpty)
-        XCTAssertNil(callService.token)
-    }
-
     func testTakeFloor() async throws {
         participantService.results[.takeFloor] = .success(())
 


### PR DESCRIPTION
You should be able to mute/unmute audio for your participant.