### PR TITLE
refactor(InfinityClient): use URLSession async API

### DIFF
--- a/Sources/PexipInfinityClient/HTTP/Internal/HTTPClient.swift
+++ b/Sources/PexipInfinityClient/HTTP/Internal/HTTPClient.swift
@@ -128,24 +128,6 @@ struct HTTPClient {
 
 // MARK: - Private extensions
 
-private extension URLSession {
-    @available(iOS, deprecated: 15.0, message: "Use the built-in API instead")
-    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-        try await withCheckedThrowingContinuation { continuation in
-            let task = self.dataTask(with: request) { data, response, error in
-                guard let data, let response else {
-                    let error = error ?? URLError(.badServerResponse)
-                    return continuation.resume(throwing: error)
-                }
-
-                continuation.resume(returning: (data, response))
-            }
-
-            task.resume()
-        }
-    }
-}
-
 private extension URLRequest {
     func withUserAgentHeader() -> URLRequest {
         var request = self


### PR DESCRIPTION
Looks like URLSession async APIs were back ported to iOS13 at some point, so we no longer need this.