### PR TITLE
feat(Media): use different audio session mode for audio and video calls

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Get changed files
         id: files
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@v42
 
       - name: Check license headers
         run: |

--- a/Examples/Conference/App/Shared/Screens/Conference/ConferenceViewModel.swift
+++ b/Examples/Conference/App/Shared/Screens/Conference/ConferenceViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Examples/Conference/App/Shared/Screens/Conference/ConferenceViewModel.swift
+++ b/Examples/Conference/App/Shared/Screens/Conference/ConferenceViewModel.swift
@@ -164,7 +164,7 @@ final class ConferenceViewModel: ObservableObject {
 
         #if os(iOS)
         Task { [weak audioSession] in
-            await audioSession?.activate(for: .call)
+            await audioSession?.activate(for: .videoCall())
         }
         #endif
     }

--- a/Sources/PexipMedia/AudioConfiguration.swift
+++ b/Sources/PexipMedia/AudioConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 Pexip AS
+// Copyright 2023-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PexipMedia/AudioConfiguration.swift
+++ b/Sources/PexipMedia/AudioConfiguration.swift
@@ -44,24 +44,43 @@ public extension AudioConfiguration {
         options: []
     )
 
-    static let call = AudioConfiguration(
-        category: .playAndRecord,
-        mode: .voiceChat,
-        options: [
+    static func audioCall(
+        mixWithOthers: Bool = false
+    ) -> AudioConfiguration {
+        call(
+            withMode: .voiceChat,
+            mixWithOthers: mixWithOthers
+        )
+    }
+
+    static func videoCall(
+        mixWithOthers: Bool = false
+    ) -> AudioConfiguration {
+        call(
+            withMode: .videoChat,
+            mixWithOthers: mixWithOthers
+        )
+    }
+
+    private static func call(
+        withMode mode: AVAudioSession.Mode,
+        mixWithOthers: Bool
+    ) -> AudioConfiguration {
+        var options: AVAudioSession.CategoryOptions = [
             .allowBluetooth,
             .allowBluetoothA2DP
         ]
-    )
 
-    static let screenCapture = AudioConfiguration(
-        category: .playAndRecord,
-        mode: .voiceChat,
-        options: [
-            .allowBluetooth,
-            .allowBluetoothA2DP,
-            .mixWithOthers
-        ]
-    )
+        if mixWithOthers {
+            options.insert(.mixWithOthers)
+        }
+
+        return AudioConfiguration(
+            category: .playAndRecord,
+            mode: mode,
+            options: options
+        )
+    }
 }
 
 #endif

--- a/Sources/PexipMedia/MediaConnectionConfig.swift
+++ b/Sources/PexipMedia/MediaConnectionConfig.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PexipMedia/MediaConnectionConfig.swift
+++ b/Sources/PexipMedia/MediaConnectionConfig.swift
@@ -45,6 +45,11 @@ public struct MediaConnectionConfig {
     /// Sets whether presentation will be mixed with main video feed.
     public let presentationInMain: Bool
 
+    #if os(iOS)
+    /// Sets whether audio session is managed outside of the SDK.
+    public var externalAudioManagement = false
+    #endif
+
     /**
      Creates a new instance of ``MediaConnectionConfig``.
 

--- a/Sources/PexipRTC/Internal/PeerConnection/PeerConnection.swift
+++ b/Sources/PexipRTC/Internal/PeerConnection/PeerConnection.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 Pexip AS
+// Copyright 2023-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -222,7 +222,7 @@ actor PeerConnection {
         logger?.debug("Data channel - new data channel created.")
     }
 
-    func contains(_ content: MediaContent) -> Bool {
+    func canSendOrReceive(_ content: MediaContent) -> Bool {
         if let transceiver = transceivers[content] {
             return transceiver.canSend || transceiver.canReceive
         } else {

--- a/Sources/PexipRTC/Internal/PeerConnection/PeerConnection.swift
+++ b/Sources/PexipRTC/Internal/PeerConnection/PeerConnection.swift
@@ -222,6 +222,14 @@ actor PeerConnection {
         logger?.debug("Data channel - new data channel created.")
     }
 
+    func contains(_ content: MediaContent) -> Bool {
+        if let transceiver = transceivers[content] {
+            return transceiver.canSend || transceiver.canReceive
+        } else {
+            return false
+        }
+    }
+
     // MARK: - Events
 
     private func subscribeToEvents() {

--- a/Sources/PexipRTC/Internal/PeerConnection/Transceiver.swift
+++ b/Sources/PexipRTC/Internal/PeerConnection/Transceiver.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 Pexip AS
+// Copyright 2023-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PexipRTC/Internal/PeerConnection/Transceiver.swift
+++ b/Sources/PexipRTC/Internal/PeerConnection/Transceiver.swift
@@ -41,6 +41,10 @@ final class Transceiver {
         transceiver.direction == .recvOnly || transceiver.direction == .sendRecv
     }
 
+    var canSend: Bool {
+        transceiver.direction == .sendOnly || transceiver.direction == .sendRecv
+    }
+
     func setDirection(_ direction: RTCRtpTransceiverDirection) throws {
         guard transceiver.direction != direction else {
             return

--- a/Sources/PexipRTC/Internal/WebRTCMediaConnection.swift
+++ b/Sources/PexipRTC/Internal/WebRTCMediaConnection.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -450,7 +450,7 @@ actor WebRTCMediaConnection: MediaConnection, DataSender {
         guard !config.externalAudioManagement else {
             return nil
         }
-        return await peerConnection.contains(.mainVideo)
+        return await peerConnection.canSendOrReceive(.mainVideo)
             ? .videoCall(mixWithOthers: mixWithOthers)
             : .audioCall(mixWithOthers: mixWithOthers)
     }

--- a/Sources/PexipRTC/Internal/WebRTCMediaConnection.swift
+++ b/Sources/PexipRTC/Internal/WebRTCMediaConnection.swift
@@ -132,7 +132,9 @@ actor WebRTCMediaConnection: MediaConnection, DataSender {
         outgoingIceCandidates.removeAll()
 
         #if os(iOS)
-        await audioSession?.deactivate()
+        if !config.externalAudioManagement {
+            await audioSession?.deactivate()
+        }
         #endif
     }
 


### PR DESCRIPTION
- Use different audio session mode for audio and video calls
- Make it possible to manage audio session outside of the SDK (New `externalAudioManagement` property in `MediaConnectionConfig`)