### PR TITLE
feat(ScreenCapture): support audio

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -134,7 +134,7 @@ let package = Package(
         ),
         .testTarget(
             name: "PexipScreenCaptureTests",
-            dependencies: ["PexipScreenCapture", "TestHelpers"]
+            dependencies: ["PexipScreenCapture"]
         ),
 
         // MARK: - TestHelpers

--- a/Sources/PexipRTC/Internal/Capturers/WebRTCScreenCapturer.swift
+++ b/Sources/PexipRTC/Internal/Capturers/WebRTCScreenCapturer.swift
@@ -130,8 +130,8 @@ final class WebRTCScreenCapturer: RTCVideoCapturer, ScreenMediaCapturerDelegate 
     }
 
     func screenMediaCapturer(
-        _ capturer: PexipScreenCapture.ScreenMediaCapturer,
-        didCaptureAudioBuffer frame: AVAudioPCMBuffer
+        _ capturer: ScreenMediaCapturer,
+        didCaptureAudioFrame frame: AudioFrame
     ) {}
 
     #if os(iOS)

--- a/Sources/PexipRTC/Internal/Capturers/WebRTCScreenCapturer.swift
+++ b/Sources/PexipRTC/Internal/Capturers/WebRTCScreenCapturer.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,6 +128,11 @@ final class WebRTCScreenCapturer: RTCVideoCapturer, ScreenMediaCapturerDelegate 
 
         delegate?.capturer(self, didCapture: rtcVideoFrame)
     }
+
+    func screenMediaCapturer(
+        _ capturer: PexipScreenCapture.ScreenMediaCapturer,
+        didCaptureAudioBuffer frame: AVAudioPCMBuffer
+    ) {}
 
     #if os(iOS)
 

--- a/Sources/PexipScreenCapture/Shared/AudioFrame.swift
+++ b/Sources/PexipScreenCapture/Shared/AudioFrame.swift
@@ -1,0 +1,46 @@
+//
+// Copyright 2024 Pexip AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import AVFoundation
+import Foundation
+
+/// An object that represents an audio frame.
+@frozen
+public struct AudioFrame {
+    public let streamDescription: AudioStreamBasicDescription
+    public let data: Data
+
+    public var isSignedInteger: Bool {
+        (streamDescription.mFormatFlags & kAudioFormatFlagIsSignedInteger) != 0
+    }
+
+    public var isFloat: Bool {
+        (streamDescription.mFormatFlags & kAudioFormatFlagIsFloat) != 0
+    }
+
+    public var isInterleaved: Bool {
+        (streamDescription.mFormatFlags & kAudioFormatFlagIsNonInterleaved) == 0
+    }
+
+    // MARK: - Init
+
+    public init(
+        streamDescription: AudioStreamBasicDescription,
+        data: Data
+    ) {
+        self.streamDescription = streamDescription
+        self.data = data
+    }
+}

--- a/Sources/PexipScreenCapture/Shared/ScreenMediaCapturer.swift
+++ b/Sources/PexipScreenCapture/Shared/ScreenMediaCapturer.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import AVFoundation
 import CoreVideo
 import Combine
 import CoreMedia
@@ -23,6 +24,11 @@ public protocol ScreenMediaCapturerDelegate: AnyObject {
     func screenMediaCapturer(
         _ capturer: ScreenMediaCapturer,
         didCaptureVideoFrame frame: VideoFrame
+    )
+
+    func screenMediaCapturer(
+        _ capturer: ScreenMediaCapturer,
+        didCaptureAudioFrame frame: AudioFrame
     )
 
     #if os(iOS)

--- a/Sources/PexipScreenCapture/iOS/BroadcastSampleHandler.swift
+++ b/Sources/PexipScreenCapture/iOS/BroadcastSampleHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ public final class BroadcastSampleHandler {
 
     private let userDefaults: UserDefaults?
     private let videoSender: BroadcastVideoSender
+    private let audioSender: BroadcastAudioSender
     private let notificationCenter = BroadcastNotificationCenter.default
     private var cancellables = Set<AnyCancellable>()
     private let keepAliveInterval: TimeInterval
@@ -59,11 +60,14 @@ public final class BroadcastSampleHandler {
         appGroup: String,
         fileManager: FileManager = .default
     ) {
-        let filePath = fileManager.broadcastVideoDataPath(appGroup: appGroup)
         let userDefaults = UserDefaults(suiteName: appGroup)
         self.init(
             videoSender: BroadcastVideoSender(
-                filePath: filePath,
+                filePath: fileManager.broadcastVideoDataPath(appGroup: appGroup),
+                fileManager: fileManager
+            ),
+            audioSender: BroadcastAudioSender(
+                filePath: fileManager.broadcastAudioDataPath(appGroup: appGroup),
                 fileManager: fileManager
             ),
             userDefaults: userDefaults
@@ -72,10 +76,12 @@ public final class BroadcastSampleHandler {
 
     init(
         videoSender: BroadcastVideoSender,
+        audioSender: BroadcastAudioSender,
         userDefaults: UserDefaults?,
         keepAliveInterval: TimeInterval = BroadcastScreenCapturer.keepAliveInterval
     ) {
         self.videoSender = videoSender
+        self.audioSender = audioSender
         self.userDefaults = userDefaults
         self.keepAliveInterval = keepAliveInterval
     }
@@ -132,18 +138,20 @@ public final class BroadcastSampleHandler {
                 return false
             }
 
-            guard
-                sampleBuffer.numSamples == 1,
-                sampleBuffer.isValid,
-                sampleBuffer.dataReadiness == .ready
-            else {
-                return false
-            }
-
             switch sampleBufferType {
             case .video:
+                guard
+                    sampleBuffer.numSamples == 1,
+                    sampleBuffer.isValid,
+                    sampleBuffer.dataReadiness == .ready
+                else {
+                    return false
+                }
+
                 return videoSender.send(sampleBuffer)
-            case .audioApp, .audioMic:
+            case .audioApp:
+                return audioSender.send(sampleBuffer)
+            case .audioMic:
                 return false
             @unknown default:
                 return false
@@ -159,6 +167,7 @@ public final class BroadcastSampleHandler {
             do {
                 let fps = BroadcastFps(value: self?.userDefaults?.broadcastFps)
                 try self?.videoSender.start(withFps: fps)
+                try self?.audioSender.start()
             } catch {
                 self?.onError(.noConnection)
             }
@@ -180,6 +189,7 @@ public final class BroadcastSampleHandler {
     private func clean() {
         stopKeepAliveTimer()
         videoSender.stop()
+        audioSender.stop()
         notificationCenter.removeObserver(self)
     }
 

--- a/Sources/PexipScreenCapture/iOS/BroadcastScreenCapturer.swift
+++ b/Sources/PexipScreenCapture/iOS/BroadcastScreenCapturer.swift
@@ -191,10 +191,19 @@ public final class BroadcastScreenCapturer: ScreenMediaCapturer {
     }
 
     private func stopReceiver() throws {
-        try videoReceiver.stop()
-        try audioReceiver.stop()
+        var resultError: Error?
+        for stop in [videoReceiver.stop, audioReceiver.stop] {
+            do {
+                _ = try stop()
+            } catch {
+                resultError = error
+            }
+        }
         userDefaults?.broadcastFps = defaultFps
         isCapturing.setValue(false)
+        if let error = resultError {
+            throw error
+        }
     }
 
     /// Write current date to shared UserDefaults to indicate that

--- a/Sources/PexipScreenCapture/iOS/BroadcastScreenCapturer.swift
+++ b/Sources/PexipScreenCapture/iOS/BroadcastScreenCapturer.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ public final class BroadcastScreenCapturer: ScreenMediaCapturer {
     private let broadcastUploadExtension: String
     private let defaultFps: UInt
     private var videoReceiver: BroadcastVideoReceiver
+    private var audioReceiver: BroadcastAudioReceiver
     private let notificationCenter = BroadcastNotificationCenter.default
     private let userDefaults: UserDefaults?
     private let isCapturing = Synchronized(false)
@@ -62,6 +63,10 @@ public final class BroadcastScreenCapturer: ScreenMediaCapturer {
                 filePath: fileManager.broadcastVideoDataPath(appGroup: appGroup),
                 fileManager: fileManager
             ),
+            audioReceiver: BroadcastAudioReceiver(
+                filePath: fileManager.broadcastAudioDataPath(appGroup: appGroup),
+                fileManager: fileManager
+            ),
             userDefaults: UserDefaults(suiteName: appGroup)
         )
     }
@@ -70,16 +75,19 @@ public final class BroadcastScreenCapturer: ScreenMediaCapturer {
         broadcastUploadExtension: String,
         defaultFps: UInt,
         videoReceiver: BroadcastVideoReceiver,
+        audioReceiver: BroadcastAudioReceiver,
         keepAliveInterval: TimeInterval = BroadcastScreenCapturer.keepAliveInterval,
         userDefaults: UserDefaults?
     ) {
         self.broadcastUploadExtension = broadcastUploadExtension
         self.defaultFps = defaultFps
         self.videoReceiver = videoReceiver
+        self.audioReceiver = audioReceiver
         self.userDefaults = userDefaults
 
         userDefaults?.broadcastFps = defaultFps
         videoReceiver.delegate = self
+        audioReceiver.delegate = self
         addNotificationObservers()
         startKeepAliveTimer(withInterval: keepAliveInterval)
     }
@@ -126,7 +134,7 @@ public final class BroadcastScreenCapturer: ScreenMediaCapturer {
             return
         }
 
-        try stopVideoReceiver()
+        try stopReceiver()
 
         switch reason {
         case .none:
@@ -143,7 +151,7 @@ public final class BroadcastScreenCapturer: ScreenMediaCapturer {
     private func addNotificationObservers() {
         notificationCenter.addObserver(self, for: .senderStarted) { [weak self] in
             if self?.isCapturing.value == false {
-                self?.startVideoReceiver()
+                self?.startReceiver()
             }
         }
 
@@ -155,7 +163,7 @@ public final class BroadcastScreenCapturer: ScreenMediaCapturer {
             var stopError: Error?
 
             do {
-                try self?.stopVideoReceiver()
+                try self?.stopReceiver()
             } catch {
                 stopError = error
             }
@@ -168,9 +176,10 @@ public final class BroadcastScreenCapturer: ScreenMediaCapturer {
         notificationCenter.removeObserver(self)
     }
 
-    private func startVideoReceiver() {
+    private func startReceiver() {
         do {
             try videoReceiver.start(withFps: BroadcastFps(value: userDefaults?.broadcastFps))
+            try audioReceiver.start()
             isCapturing.setValue(true)
             notificationCenter.post(.receiverStarted)
             delegate?.screenMediaCapturerDidStart(self)
@@ -181,8 +190,9 @@ public final class BroadcastScreenCapturer: ScreenMediaCapturer {
         }
     }
 
-    private func stopVideoReceiver() throws {
+    private func stopReceiver() throws {
         try videoReceiver.stop()
+        try audioReceiver.stop()
         userDefaults?.broadcastFps = defaultFps
         isCapturing.setValue(false)
     }
@@ -218,6 +228,10 @@ public final class BroadcastScreenCapturer: ScreenMediaCapturer {
     private func onCapture(videoFrame: VideoFrame) {
         delegate?.screenMediaCapturer(self, didCaptureVideoFrame: videoFrame)
     }
+
+    private func onCapture(audioFrame: AudioFrame) {
+        delegate?.screenMediaCapturer(self, didCaptureAudioFrame: audioFrame)
+    }
 }
 
 // MARK: - BroadcastVideoReceiverDelegate
@@ -228,6 +242,17 @@ extension BroadcastScreenCapturer: BroadcastVideoReceiverDelegate {
         didReceiveVideoFrame videoFrame: VideoFrame
     ) {
         onCapture(videoFrame: videoFrame)
+    }
+}
+
+// MARK: - BroadcastAudioReceiverDelegate
+
+extension BroadcastScreenCapturer: BroadcastAudioReceiverDelegate {
+    func broadcastAudioReceiver(
+        _ receiver: BroadcastAudioReceiver,
+        didReceiveAudioFrame frame: AudioFrame
+    ) {
+        onCapture(audioFrame: frame)
     }
 }
 

--- a/Sources/PexipScreenCapture/iOS/Internal/Audio/AudioBufferHeader.swift
+++ b/Sources/PexipScreenCapture/iOS/Internal/Audio/AudioBufferHeader.swift
@@ -1,0 +1,70 @@
+//
+// Copyright 2024 Pexip AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if os(iOS)
+
+import AVFoundation
+import Foundation
+
+struct AudioBufferHeader {
+    static let size = MemoryLayout<AudioBufferHeader>.size
+
+    var streamDescription = AudioStreamBasicDescription()
+    var dataSize: UInt32 = 0
+
+    // MARK: - Encoding/Decoding
+
+    func encoded() -> Data? {
+        var offset = 0
+        var header = self
+
+        guard var data = Self.allocateData() else {
+            return nil
+        }
+
+        data.withUnsafeMutableBytes { pointer in
+            guard let baseAddress = pointer.baseAddress, !pointer.isEmpty else {
+                return
+            }
+            baseAddress.copyMemory(from: &header, offset: &offset)
+        }
+
+        return data
+    }
+
+    static func decode(from data: Data) -> AudioBufferHeader? {
+        data.withUnsafeBytes { pointer -> AudioBufferHeader? in
+            guard let baseAddress = pointer.baseAddress, !pointer.isEmpty else {
+                return nil
+            }
+
+            var offset = 0
+            var header = AudioBufferHeader()
+            baseAddress.copyMemory(to: &header, offset: &offset)
+
+            guard header.dataSize > 0 else {
+                return nil
+            }
+
+            return header
+        }
+    }
+
+    static func allocateData() -> Data? {
+        .allocateData(withSize: Self.size)
+    }
+}
+
+#endif

--- a/Sources/PexipScreenCapture/iOS/Internal/Audio/AudioBufferMessage.swift
+++ b/Sources/PexipScreenCapture/iOS/Internal/Audio/AudioBufferMessage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,16 +15,28 @@
 
 #if os(iOS)
 
-struct BroadcastFps {
-    static let minValue: UInt = 15
-    static let maxValue: UInt = 30
+import Foundation
 
-    let value: UInt
+enum AudioBufferMessage {
+    case header(AudioBufferHeader)
+    case data(Data)
 
-    init(value: UInt?) {
-        // The broadcast extension has hard memory limit of 50MB.
-        // Use lower frame rate to reduce the memory load.
-        self.value = min(value ?? Self.minValue, Self.maxValue)
+    var size: Int {
+        switch self {
+        case .header:
+            return AudioBufferHeader.size
+        case .data(let data):
+            return data.count
+        }
+    }
+
+    func encoded() -> Data? {
+        switch self {
+        case .header(let header):
+            return header.encoded()
+        case .data(let data):
+            return data
+        }
     }
 }
 

--- a/Sources/PexipScreenCapture/iOS/Internal/Audio/BroadcastAudioReceiver.swift
+++ b/Sources/PexipScreenCapture/iOS/Internal/Audio/BroadcastAudioReceiver.swift
@@ -1,0 +1,158 @@
+//
+// Copyright 2024 Pexip AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if os(iOS)
+
+import AVFoundation
+import CoreVideo
+
+// MARK: - BroadcastAudioReceiverDelegate
+
+protocol BroadcastAudioReceiverDelegate: AnyObject {
+    func broadcastAudioReceiver(
+        _ receiver: BroadcastAudioReceiver,
+        didReceiveAudioFrame frame: AudioFrame
+    )
+}
+
+// MARK: - BroadcastAudioReceiver
+
+final class BroadcastAudioReceiver {
+    weak var delegate: BroadcastAudioReceiverDelegate?
+    var isRunning: Bool { _isRunning.value }
+
+    private let filePath: String
+    private let fileManager: FileManager
+    private var file: NamedPipeFile?
+    private let queue = DispatchQueue(
+        label: "com.pexip.PexipScreenCapture.BroadcastAudioReceiver",
+        qos: .userInteractive,
+        autoreleaseFrequency: .workItem
+    )
+    private var source: DispatchSourceRead?
+    private var header: AudioBufferHeader?
+    private let _isRunning = Synchronized(false)
+
+    // MARK: - Init
+
+    init(
+        filePath: String,
+        fileManager: FileManager = .default
+    ) {
+        self.filePath = filePath
+        self.fileManager = fileManager
+    }
+
+    deinit {
+        _ = try? stop()
+    }
+
+    // MARK: - Internal
+
+    @discardableResult
+    func start() throws -> Bool {
+        guard !_isRunning.value else {
+            return false
+        }
+
+        file = try fileManager.namedPipeFile(
+            atPath: filePath,
+            createIfNeeded: true
+        )
+
+        guard let fileDescriptor = file?.fileDescriptor else {
+            throw BroadcastError.noConnection
+        }
+
+        _isRunning.setValue(true)
+
+        source = DispatchSource.makeReadSource(
+            fileDescriptor: fileDescriptor,
+            queue: queue
+        )
+        source?.setEventHandler { [weak self] in
+            self?.handleSourceEvents()
+        }
+        source?.resume()
+
+        return true
+    }
+
+    @discardableResult
+    func stop() throws -> Bool {
+        guard _isRunning.value else {
+            return false
+        }
+
+        _isRunning.setValue(false)
+        source?.cancel()
+        source = nil
+
+        let filePath = file?.path
+        file = nil
+        header = nil
+
+        if let filePath {
+            try fileManager.removeItem(atPath: filePath)
+        }
+
+        return true
+    }
+
+    // MARK: - Private
+
+    private func handleSourceEvents() {
+        if let header {
+            readAudioData(withHeader: header)
+            self.header = nil
+        } else {
+            readHeader()
+        }
+    }
+
+    private func readHeader() {
+        guard let file, var data = AudioBufferHeader.allocateData() else {
+            return
+        }
+
+        guard file.read(into: &data) == AudioBufferHeader.size else {
+            return
+        }
+
+        header = AudioBufferHeader.decode(from: data)
+    }
+
+    private func readAudioData(withHeader header: AudioBufferHeader) {
+        guard
+            let file,
+            var audioData = Data.allocateData(withSize: Int(header.dataSize))
+        else {
+            return
+        }
+
+        guard file.read(into: &audioData) == header.dataSize else {
+            return
+        }
+
+        let frame = AudioFrame(
+            streamDescription: header.streamDescription,
+            data: audioData
+        )
+
+        delegate?.broadcastAudioReceiver(self, didReceiveAudioFrame: frame)
+    }
+}
+
+#endif

--- a/Sources/PexipScreenCapture/iOS/Internal/Audio/BroadcastAudioSender.swift
+++ b/Sources/PexipScreenCapture/iOS/Internal/Audio/BroadcastAudioSender.swift
@@ -1,0 +1,164 @@
+//
+// Copyright 2024 Pexip AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if os(iOS)
+
+import AVFoundation
+import CoreMedia
+
+final class BroadcastAudioSender {
+    var isRunning: Bool { _isRunning.value }
+
+    private static let maxQueueSize = 2 * 1024 * 1024
+    private let filePath: String
+    private let fileManager: FileManager
+    private var file: NamedPipeFile?
+    private let queue = DispatchQueue(
+        label: "com.pexip.PexipScreenCapture.BroadcastAudioSender",
+        qos: .userInteractive,
+        autoreleaseFrequency: .workItem
+    )
+    private var source: DispatchSourceWrite?
+    private var messageQueue = [AudioBufferMessage]()
+    private let _isRunning = Synchronized(false)
+
+    // MARK: - Init
+
+    init(
+        filePath: String,
+        fileManager: FileManager = .default
+    ) {
+        self.filePath = filePath
+        self.fileManager = fileManager
+    }
+
+    deinit {
+        stop()
+    }
+
+    // MARK: - Internal
+
+    @discardableResult
+    func start() throws -> Bool {
+        guard !_isRunning.value else {
+            return false
+        }
+
+        file = try fileManager.namedPipeFile(atPath: filePath)
+
+        guard let fileDescriptor = file?.fileDescriptor else {
+            throw BroadcastError.noConnection
+        }
+
+        _isRunning.setValue(true)
+
+        source = DispatchSource.makeWriteSource(
+            fileDescriptor: fileDescriptor,
+            queue: queue
+        )
+
+        source?.setEventHandler { [weak self] in
+            self?.handleSourceEvents()
+        }
+        source?.activate()
+
+        return true
+    }
+
+    @discardableResult
+    func stop() -> Bool {
+        guard _isRunning.value else {
+            return false
+        }
+
+        _isRunning.setValue(false)
+        source?.cancel()
+        source = nil
+        file = nil
+        messageQueue.removeAll()
+
+        return true
+    }
+
+    @discardableResult
+    func send(_ sampleBuffer: CMSampleBuffer) -> Bool {
+        guard _isRunning.value else {
+            return false
+        }
+
+        queue.async { [weak self] in
+            try? self?.write(sampleBuffer)
+        }
+
+        return true
+    }
+
+    // MARK: - Private
+
+    private func write(_ buffer: CMSampleBuffer) throws {
+        guard messageQueue.reduce(0, { $0 + $1.size }) < Self.maxQueueSize else {
+            return
+        }
+
+        let messages: [AudioBufferMessage] = try buffer.withAudioBufferList { list, _ in
+            guard
+                let streamDescription = buffer.formatDescription?.audioStreamBasicDescription,
+                let firstBuffer = list.first,
+                let firstBufferPointer = firstBuffer.mData
+            else {
+                return []
+            }
+
+            let header = AudioBufferHeader(
+                streamDescription: streamDescription,
+                dataSize: firstBuffer.mDataByteSize * UInt32(list.count)
+            )
+
+            guard let pointer = malloc(Int(header.dataSize)) else {
+                return []
+            }
+
+            memcpy(pointer, firstBufferPointer, Int(header.dataSize))
+
+            let data = Data(
+                bytesNoCopy: pointer,
+                count: Int(header.dataSize),
+                deallocator: .free
+            )
+
+            return [.header(header), .data(data)]
+        }
+
+        messageQueue.append(contentsOf: messages)
+    }
+
+    private func handleSourceEvents() {
+        guard let file else {
+            return
+        }
+
+        guard !messageQueue.isEmpty else {
+            return
+        }
+
+        guard let data = messageQueue.removeFirst().encoded() else {
+            return
+        }
+
+        file.write(data)
+    }
+}
+
+#endif

--- a/Sources/PexipScreenCapture/iOS/Internal/Audio/NamedPipeFile.swift
+++ b/Sources/PexipScreenCapture/iOS/Internal/Audio/NamedPipeFile.swift
@@ -1,0 +1,94 @@
+//
+// Copyright 2024 Pexip AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if os(iOS)
+
+import Foundation
+
+final class NamedPipeFile {
+    static let bufferSize = 8192
+
+    let path: String
+    let fileDescriptor: Int32
+
+    // MARK: - Init
+
+    init(path: String, fileDescriptor: Int32) {
+        self.path = path
+        self.fileDescriptor = fileDescriptor
+    }
+
+    deinit {
+        close(fileDescriptor)
+    }
+
+    // MARK: - Internal
+
+    @discardableResult
+    func write(_ data: Data) -> Int {
+        var offset = 0
+        while offset < data.count {
+            let count = data.count - offset
+            let bytes = write(data, offset: offset, count: count)
+            if bytes > 0 {
+                offset += bytes
+            }
+        }
+        return offset
+    }
+
+    func write(_ data: Data, offset: Int, count: Int) -> Int {
+        data.withUnsafeBytes { pointer -> Int in
+            if let baseAddress = pointer.baseAddress {
+                return Darwin.write(
+                    fileDescriptor,
+                    baseAddress.advanced(by: offset),
+                    min(count, Self.bufferSize)
+                )
+            } else {
+                return -1
+            }
+        }
+    }
+
+    @discardableResult
+    func read(into data: inout Data) -> Int {
+        var offset = 0
+        while offset < data.count {
+            let count = data.count - offset
+            let bytes = read(into: &data, offset: offset, count: count)
+            if bytes > 0 {
+                offset += bytes
+            }
+        }
+        return offset
+    }
+
+    func read(into data: inout Data, offset: Int, count: Int) -> Int {
+        data.withUnsafeMutableBytes { pointer -> Int in
+            if let baseAddress = pointer.baseAddress {
+                return Darwin.read(
+                    fileDescriptor,
+                    baseAddress.advanced(by: offset),
+                    min(count, Self.bufferSize)
+                )
+            } else {
+                return -1
+            }
+        }
+    }
+}
+
+#endif

--- a/Sources/PexipScreenCapture/iOS/Internal/Extensions/Data+Broadcast.swift
+++ b/Sources/PexipScreenCapture/iOS/Internal/Extensions/Data+Broadcast.swift
@@ -1,0 +1,25 @@
+//
+// Copyright 2024 Pexip AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+extension Data {
+    static func allocateData(withSize size: Int) -> Data? {
+        guard let pointer = malloc(size) else {
+            return nil
+        }
+        return Data(bytesNoCopy: pointer, count: size, deallocator: .free)
+    }
+}

--- a/Sources/PexipScreenCapture/iOS/Internal/Extensions/UnsafeRawPointer+Broadcast.swift
+++ b/Sources/PexipScreenCapture/iOS/Internal/Extensions/UnsafeRawPointer+Broadcast.swift
@@ -1,0 +1,36 @@
+//
+// Copyright 2024 Pexip AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+extension UnsafeRawPointer {
+    func copyMemory<T>(to value: inout T, offset: inout Int) {
+        let count = MemoryLayout<T>.size
+        withUnsafeMutablePointer(to: &value) { value in
+            memcpy(value, advanced(by: offset), count)
+            offset += count
+        }
+    }
+}
+
+extension UnsafeMutableRawPointer {
+    func copyMemory<T>(from value: inout T, offset: inout Int) {
+        let count = MemoryLayout<T>.size
+        withUnsafeMutablePointer(to: &value) { value in
+            memcpy(advanced(by: offset), value, count)
+            offset += count
+        }
+    }
+}

--- a/Sources/PexipScreenCapture/iOS/Internal/Video/BroadcastDisplayLink.swift
+++ b/Sources/PexipScreenCapture/iOS/Internal/Video/BroadcastDisplayLink.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PexipScreenCapture/iOS/Internal/Video/BroadcastFps.swift
+++ b/Sources/PexipScreenCapture/iOS/Internal/Video/BroadcastFps.swift
@@ -1,0 +1,31 @@
+//
+// Copyright 2022-2024 Pexip AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if os(iOS)
+
+struct BroadcastFps {
+    static let minValue: UInt = 15
+    static let maxValue: UInt = 30
+
+    let value: UInt
+
+    init(value: UInt?) {
+        // The broadcast extension has hard memory limit of 50MB.
+        // Use lower frame rate to reduce the memory load.
+        self.value = min(value ?? Self.minValue, Self.maxValue)
+    }
+}
+
+#endif

--- a/Sources/PexipScreenCapture/iOS/Internal/Video/BroadcastVideoReceiver.swift
+++ b/Sources/PexipScreenCapture/iOS/Internal/Video/BroadcastVideoReceiver.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PexipScreenCapture/iOS/Internal/Video/BroadcastVideoSender.swift
+++ b/Sources/PexipScreenCapture/iOS/Internal/Video/BroadcastVideoSender.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PexipScreenCapture/iOS/Internal/Video/MemoryMappedFile.swift
+++ b/Sources/PexipScreenCapture/iOS/Internal/Video/MemoryMappedFile.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PexipScreenCapture/macOS/Internal/New/NewScreenMediaCapturer.swift
+++ b/Sources/PexipScreenCapture/macOS/Internal/New/NewScreenMediaCapturer.swift
@@ -59,6 +59,9 @@ final class NewScreenMediaCapturer<Factory: ScreenCaptureStreamFactory>: NSObjec
 
     deinit {
         try? stream?.removeStreamOutput(self, type: .screen)
+        if #available(macOS 13.0, *) {
+            try? stream?.removeStreamOutput(self, type: .audio)
+        }
         stream?.stopCapture(completionHandler: { _ in })
     }
 

--- a/Sources/PexipScreenCapture/macOS/Internal/New/NewScreenMediaCapturer.swift
+++ b/Sources/PexipScreenCapture/macOS/Internal/New/NewScreenMediaCapturer.swift
@@ -60,7 +60,9 @@ final class NewScreenMediaCapturer<Factory: ScreenCaptureStreamFactory>: NSObjec
     deinit {
         try? stream?.removeStreamOutput(self, type: .screen)
         if #available(macOS 13.0, *) {
-            try? stream?.removeStreamOutput(self, type: .audio)
+            if capturesAudio {
+                try? stream?.removeStreamOutput(self, type: .audio)
+            }
         }
         stream?.stopCapture(completionHandler: { _ in })
     }
@@ -111,7 +113,9 @@ final class NewScreenMediaCapturer<Factory: ScreenCaptureStreamFactory>: NSObjec
         isCapturing = false
         try stream?.removeStreamOutput(self, type: .screen)
         if #available(macOS 13.0, *) {
-            try stream?.removeStreamOutput(self, type: .audio)
+            if capturesAudio {
+                try stream?.removeStreamOutput(self, type: .audio)
+            }
         }
         try await stream?.stopCapture()
         stream = nil
@@ -128,7 +132,9 @@ final class NewScreenMediaCapturer<Factory: ScreenCaptureStreamFactory>: NSObjec
         case .screen:
             handleVideoSampleBuffer(sampleBuffer)
         case .audio:
-            handleAudioSampleBuffer(sampleBuffer)
+            if capturesAudio {
+                handleAudioSampleBuffer(sampleBuffer)
+            }
         @unknown default:
             break
         }

--- a/Sources/PexipScreenCapture/macOS/Internal/New/NewScreenMediaCapturer.swift
+++ b/Sources/PexipScreenCapture/macOS/Internal/New/NewScreenMediaCapturer.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 #if os(macOS)
 
 import AppKit
+import AVFoundation
 import Combine
 import CoreMedia
 
@@ -33,20 +34,26 @@ final class NewScreenMediaCapturer<Factory: ScreenCaptureStreamFactory>: NSObjec
                                                                          SCStreamOutput,
                                                                          SCStreamDelegate {
     let source: ScreenMediaSource
+    let capturesAudio: Bool
     weak var delegate: ScreenMediaCapturerDelegate?
     private(set) var isCapturing = false
 
     private let streamFactory: Factory
     private var stream: SCStream?
-    private let dispatchQueue = DispatchQueue(
-        label: "com.pexip.PexipScreenCapture.NewScreenMediaCapturer",
+    private let videoSampleBufferQueue = DispatchQueue(
+        label: "com.pexip.PexipScreenCapture.videoSampleBufferQueue",
+        qos: .userInteractive
+    )
+    private let audioSampleBufferQueue = DispatchQueue(
+        label: "com.pexip.PexipScreenCapture.audioSampleBufferQueue",
         qos: .userInteractive
     )
 
     // MARK: - Init
 
-    init(source: ScreenMediaSource, streamFactory: Factory) {
+    init(source: ScreenMediaSource, capturesAudio: Bool, streamFactory: Factory) {
         self.source = source
+        self.capturesAudio = capturesAudio
         self.streamFactory = streamFactory
     }
 
@@ -69,6 +76,9 @@ final class NewScreenMediaCapturer<Factory: ScreenCaptureStreamFactory>: NSObjec
         streamConfig.minimumFrameInterval = CMTime(fps: fps)
         streamConfig.width = Int(outputDimensions.width)
         streamConfig.height = Int(outputDimensions.height)
+        if #available(macOS 13.0, *) {
+            streamConfig.capturesAudio = capturesAudio
+        }
 
         stream = try await streamFactory.createStream(
             mediaSource: source,
@@ -76,7 +86,20 @@ final class NewScreenMediaCapturer<Factory: ScreenCaptureStreamFactory>: NSObjec
             delegate: nil
         )
 
-        try stream?.addStreamOutput(self, type: .screen, sampleHandlerQueue: dispatchQueue)
+        try stream?.addStreamOutput(
+            self,
+            type: .screen,
+            sampleHandlerQueue: videoSampleBufferQueue
+        )
+        if #available(macOS 13.0, *) {
+            if capturesAudio {
+                try stream?.addStreamOutput(
+                    self,
+                    type: .audio,
+                    sampleHandlerQueue: audioSampleBufferQueue
+                )
+            }
+        }
         try await stream?.startCapture()
         isCapturing = true
     }
@@ -84,6 +107,9 @@ final class NewScreenMediaCapturer<Factory: ScreenCaptureStreamFactory>: NSObjec
     func stopCapture() async throws {
         isCapturing = false
         try stream?.removeStreamOutput(self, type: .screen)
+        if #available(macOS 13.0, *) {
+            try stream?.removeStreamOutput(self, type: .audio)
+        }
         try await stream?.stopCapture()
         stream = nil
     }
@@ -95,6 +121,17 @@ final class NewScreenMediaCapturer<Factory: ScreenCaptureStreamFactory>: NSObjec
         didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
         of type: SCStreamOutputType
     ) {
+        switch type {
+        case .screen:
+            handleVideoSampleBuffer(sampleBuffer)
+        case .audio:
+            handleAudioSampleBuffer(sampleBuffer)
+        @unknown default:
+            break
+        }
+    }
+
+    private func handleVideoSampleBuffer(_ sampleBuffer: CMSampleBuffer) {
         guard let attachments = (CMSampleBufferGetSampleAttachmentsArray(
             sampleBuffer,
             createIfNecessary: false
@@ -146,6 +183,29 @@ final class NewScreenMediaCapturer<Factory: ScreenCaptureStreamFactory>: NSObjec
             }
         @unknown default:
             break
+        }
+    }
+
+    private func handleAudioSampleBuffer(_ buffer: CMSampleBuffer) {
+        try? buffer.withAudioBufferList { list, _ in
+            guard
+                let streamDescription = buffer.formatDescription?.audioStreamBasicDescription,
+                let firstBuffer = list.first,
+                let firstBufferPointer = firstBuffer.mData
+            else {
+                return
+            }
+
+            let frame = AudioFrame(
+                streamDescription: streamDescription,
+                data: Data(
+                    bytesNoCopy: firstBufferPointer,
+                    count: Int(firstBuffer.mDataByteSize) * list.count,
+                    deallocator: .none
+                )
+            )
+
+            delegate?.screenMediaCapturer(self, didCaptureAudioFrame: frame)
         }
     }
 }

--- a/Sources/PexipScreenCapture/macOS/ScreenMediaSource.swift
+++ b/Sources/PexipScreenCapture/macOS/ScreenMediaSource.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,6 +50,21 @@ public enum ScreenMediaSource: Equatable {
     }
 
     /// Creates a new screen media capturer for the specified media source.
+    @available(macOS 13.0, *)
+    public static func createCapturer(
+        for mediaSource: ScreenMediaSource,
+        capturesAudio: Bool
+    ) -> ScreenMediaCapturer {
+        // Use ScreenCaptureKit
+        // https://developer.apple.com/documentation/screencapturekit
+        return NewScreenMediaCapturer(
+            source: mediaSource,
+            capturesAudio: capturesAudio,
+            streamFactory: SCStreamFactory()
+        )
+    }
+
+    /// Creates a new screen media capturer for the specified media source.
     public static func createCapturer(
         for mediaSource: ScreenMediaSource
     ) -> ScreenMediaCapturer {
@@ -58,6 +73,7 @@ public enum ScreenMediaSource: Equatable {
             // https://developer.apple.com/documentation/screencapturekit
             return NewScreenMediaCapturer(
                 source: mediaSource,
+                capturesAudio: false,
                 streamFactory: SCStreamFactory()
             )
         } else {

--- a/Tests/PexipScreenCaptureTests/CMSampleBuffer+Stubs.swift
+++ b/Tests/PexipScreenCaptureTests/CMSampleBuffer+Stubs.swift
@@ -1,0 +1,135 @@
+//
+// Copyright 2024 Pexip AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import CoreMedia
+import ReplayKit
+
+@available(macOS 11.0, *)
+public extension CMSampleBuffer {
+    static func stub(
+        width: Int = 1920,
+        height: Int = 1080,
+        displayTime: CMTime = CMClockGetTime(CMClockGetHostTimeClock()),
+        pixelFormat: OSType = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+        orientation: CGImagePropertyOrientation? = .up
+    ) -> CMSampleBuffer {
+        var pixelBuffer: CVPixelBuffer?
+
+        CVPixelBufferCreate(
+            kCFAllocatorDefault,
+            width,
+            height,
+            pixelFormat,
+            nil,
+            &pixelBuffer
+        )
+
+        var info = CMSampleTimingInfo()
+        info.presentationTimeStamp = CMTime.zero
+        info.duration = CMTime.invalid
+        info.decodeTimeStamp = CMTime.invalid
+
+        var formatDesc: CMFormatDescription?
+        CMVideoFormatDescriptionCreateForImageBuffer(
+            allocator: kCFAllocatorDefault,
+            imageBuffer: pixelBuffer!,
+            formatDescriptionOut: &formatDesc
+        )
+
+        var sampleBuffer: CMSampleBuffer?
+
+        CMSampleBufferCreateReadyWithImageBuffer(
+            allocator: kCFAllocatorDefault,
+            imageBuffer: pixelBuffer!,
+            formatDescription: formatDesc!,
+            sampleTiming: &info,
+            sampleBufferOut: &sampleBuffer
+        )
+
+        if let orientation = orientation {
+            CMSetAttachment(
+                sampleBuffer!,
+                key: RPVideoSampleOrientationKey as CFString,
+                value: orientation.rawValue as CFNumber,
+                attachmentMode: 0
+            )
+        }
+
+        return sampleBuffer!
+    }
+
+    // swiftlint:disable function_body_length
+    static func audioStub(sampleRate: Float64 = 44100.0) -> CMSampleBuffer {
+        let numFrames: CMItemCount = 1024
+        var asbd = AudioStreamBasicDescription(
+            mSampleRate: 44100.0,
+            mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked,
+            mBytesPerPacket: 2,
+            mFramesPerPacket: 1,
+            mBytesPerFrame: 2,
+            mChannelsPerFrame: 1,
+            mBitsPerChannel: 16,
+            mReserved: 0
+        )
+        var formatDescription: CMAudioFormatDescription?
+        CMAudioFormatDescriptionCreate(
+            allocator: kCFAllocatorDefault,
+            asbd: &asbd,
+            layoutSize: 0,
+            layout: nil,
+            magicCookieSize: 0,
+            magicCookie: nil,
+            extensions: nil,
+            formatDescriptionOut: &formatDescription
+        )
+
+        let dataSize = numFrames * 2
+        let audioData = malloc(dataSize)!
+        memset(audioData, 0, dataSize)
+
+        var blockBuffer: CMBlockBuffer?
+        CMBlockBufferCreateWithMemoryBlock(
+            allocator: kCFAllocatorDefault,
+            memoryBlock: audioData,
+            blockLength: dataSize,
+            blockAllocator: kCFAllocatorNull,
+            customBlockSource: nil,
+            offsetToData: 0,
+            dataLength: dataSize,
+            flags: 0,
+            blockBufferOut: &blockBuffer
+        )
+
+        var sampleBuffer: CMSampleBuffer?
+        CMAudioSampleBufferCreateWithPacketDescriptions(
+            allocator: kCFAllocatorDefault,
+            dataBuffer: blockBuffer!,
+            dataReady: true,
+            makeDataReadyCallback: nil,
+            refcon: nil,
+            formatDescription: formatDescription!,
+            sampleCount: numFrames,
+            presentationTimeStamp: .zero,
+            packetDescriptions: nil,
+            sampleBufferOut: &sampleBuffer
+        )
+
+        free(audioData)
+
+        return sampleBuffer!
+    }
+    // swiftlint:enable function_body_length
+}

--- a/Tests/PexipScreenCaptureTests/CMSampleBuffer+Stubs.swift
+++ b/Tests/PexipScreenCaptureTests/CMSampleBuffer+Stubs.swift
@@ -17,7 +17,7 @@ import CoreMedia
 import ReplayKit
 
 @available(macOS 11.0, *)
-public extension CMSampleBuffer {
+extension CMSampleBuffer {
     static func stub(
         width: Int = 1920,
         height: Int = 1080,

--- a/Tests/PexipScreenCaptureTests/Shared/AudioFrameTests.swift
+++ b/Tests/PexipScreenCaptureTests/Shared/AudioFrameTests.swift
@@ -1,0 +1,71 @@
+//
+// Copyright 2024 Pexip AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import AVFoundation
+@testable import PexipScreenCapture
+
+final class AudioFrameTests: XCTestCase {
+    private let width = 1920
+    private let height = 1080
+    private let displayTimeNs: UInt64 = 10_000
+    private let pixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
+    private var pixelBuffer: CVPixelBuffer!
+    private var videoFrame: VideoFrame!
+
+    // MARK: - Setup
+
+    func testIsSignedInteger() {
+        do {
+            let frame = AudioFrame(streamDescription: .init(), data: Data())
+            XCTAssertFalse(frame.isSignedInteger)
+        }
+
+        do {
+            var streamDescription = AudioStreamBasicDescription()
+            streamDescription.mFormatFlags = kAudioFormatFlagIsSignedInteger
+            let frame = AudioFrame(streamDescription: streamDescription, data: Data())
+            XCTAssertTrue(frame.isSignedInteger)
+        }
+    }
+
+    func testIsFloat() {
+        do {
+            let frame = AudioFrame(streamDescription: .init(), data: Data())
+            XCTAssertFalse(frame.isFloat)
+        }
+
+        do {
+            var streamDescription = AudioStreamBasicDescription()
+            streamDescription.mFormatFlags = kAudioFormatFlagIsFloat
+            let frame = AudioFrame(streamDescription: streamDescription, data: Data())
+            XCTAssertTrue(frame.isFloat)
+        }
+    }
+
+    func testIsInterleaved() {
+        do {
+            let frame = AudioFrame(streamDescription: .init(), data: Data())
+            XCTAssertTrue(frame.isInterleaved)
+        }
+
+        do {
+            var streamDescription = AudioStreamBasicDescription()
+            streamDescription.mFormatFlags = kAudioFormatFlagIsNonInterleaved
+            let frame = AudioFrame(streamDescription: streamDescription, data: Data())
+            XCTAssertFalse(frame.isInterleaved)
+        }
+    }
+}

--- a/Tests/PexipScreenCaptureTests/Shared/AudioFrameTests.swift
+++ b/Tests/PexipScreenCaptureTests/Shared/AudioFrameTests.swift
@@ -18,15 +18,6 @@ import AVFoundation
 @testable import PexipScreenCapture
 
 final class AudioFrameTests: XCTestCase {
-    private let width = 1920
-    private let height = 1080
-    private let displayTimeNs: UInt64 = 10_000
-    private let pixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
-    private var pixelBuffer: CVPixelBuffer!
-    private var videoFrame: VideoFrame!
-
-    // MARK: - Setup
-
     func testIsSignedInteger() {
         do {
             let frame = AudioFrame(streamDescription: .init(), data: Data())

--- a/Tests/PexipScreenCaptureTests/iOS/BroadcastScreenCapturerTests.swift
+++ b/Tests/PexipScreenCaptureTests/iOS/BroadcastScreenCapturerTests.swift
@@ -193,7 +193,7 @@ final class BroadcastScreenCapturerTests: XCTestCase {
 
         notificationCenter.post(.senderStarted)
 
-        wait(for: [delegateExpectation], timeout: 10.1)
+        wait(for: [delegateExpectation], timeout: 0.1)
     }
 
     func testSenderFinishedWhenNotCapturing() {

--- a/Tests/PexipScreenCaptureTests/iOS/Internal/Audio/AudioBufferHeaderTests.swift
+++ b/Tests/PexipScreenCaptureTests/iOS/Internal/Audio/AudioBufferHeaderTests.swift
@@ -1,0 +1,55 @@
+//
+// Copyright 2024 Pexip AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import AVFoundation
+
+#if os(iOS)
+
+import XCTest
+@testable import PexipScreenCapture
+
+final class AudioBufferHeaderTests: XCTestCase {
+    func testEncodeDecode() {
+        var header = AudioBufferHeader()
+        header.dataSize = 123
+        header.streamDescription.mSampleRate = 44_100
+
+        let data = header.encoded()
+        XCTAssertNotNil(data)
+        XCTAssertEqual(data?.count, AudioBufferHeader.size)
+
+        let decoded = AudioBufferHeader.decode(from: data!)
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(decoded?.dataSize, 123)
+        XCTAssertEqual(
+            decoded?.streamDescription.mSampleRate,
+            header.streamDescription.mSampleRate
+        )
+    }
+
+    func testDecodeWithNoData() {
+        let decoded = AudioBufferHeader.decode(from: Data())
+        XCTAssertNil(decoded)
+    }
+
+    func testDecodeWithInvalidData() {
+        let data = Data(count: AudioBufferHeader.size - 1)
+        let decoded = AudioBufferHeader.decode(from: data)
+        XCTAssertNil(decoded)
+    }
+}
+
+#endif

--- a/Tests/PexipScreenCaptureTests/iOS/Internal/Audio/AudioBufferMessageTests.swift
+++ b/Tests/PexipScreenCaptureTests/iOS/Internal/Audio/AudioBufferMessageTests.swift
@@ -1,0 +1,51 @@
+//
+// Copyright 2024 Pexip AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if os(iOS)
+
+import Foundation
+import AVFoundation
+import XCTest
+@testable import PexipScreenCapture
+
+final class AudioBufferMessageTests: XCTestCase {
+    func testSize() {
+        XCTAssertEqual(AudioBufferMessage.data(Data(count: 1)).size, 1)
+        XCTAssertEqual(
+            AudioBufferMessage.header(AudioBufferHeader()).size,
+            AudioBufferHeader.size
+        )
+    }
+
+    func testEncoded() {
+        do {
+            let data = Data(count: 1)
+            let message = AudioBufferMessage.data(data)
+            let encoded = message.encoded()
+            XCTAssertEqual(encoded, data)
+        }
+
+        do {
+            var header = AudioBufferHeader()
+            header.dataSize = 123
+            let message = AudioBufferMessage.header(header)
+            let encoded = message.encoded()
+            XCTAssertNotNil(encoded)
+            XCTAssertEqual(encoded?.count, AudioBufferHeader.size)
+        }
+    }
+}
+
+#endif

--- a/Tests/PexipScreenCaptureTests/iOS/Internal/Audio/BroadcastAudioReceiverTests.swift
+++ b/Tests/PexipScreenCaptureTests/iOS/Internal/Audio/BroadcastAudioReceiverTests.swift
@@ -1,0 +1,128 @@
+//
+// Copyright 2024 Pexip AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if os(iOS)
+
+import XCTest
+import CoreMedia
+@testable import PexipScreenCapture
+
+final class BroadcastAudioReceiverTests: XCTestCase {
+    private var receiver: BroadcastAudioReceiver!
+    private let filePath = NSTemporaryDirectory().appending("/test")
+    private let fileManager = FileManager.default
+
+    // MARK: - Setup
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        receiver = BroadcastAudioReceiver(filePath: filePath)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        try receiver?.stop()
+        try? fileManager.removeItem(atPath: filePath)
+    }
+
+    // MARK: - Tests
+
+    func testStart() throws {
+        let started = try receiver.start()
+
+        XCTAssertTrue(started)
+        XCTAssertTrue(receiver.isRunning)
+        XCTAssertTrue(fileManager.fileExists(atPath: filePath))
+    }
+
+    func testStartWhenRunning() throws {
+        XCTAssertTrue(try receiver.start())
+        XCTAssertTrue(receiver.isRunning)
+
+        XCTAssertFalse(try receiver.start())
+        XCTAssertTrue(receiver.isRunning)
+    }
+
+    func testStartWithNoFileCreated() throws {
+        // 1. Create receiver with invalid file path
+        receiver = BroadcastAudioReceiver(filePath: "")
+
+        // 2. Try to start receiver
+        do {
+            try receiver.start()
+            XCTFail("Should fail with error")
+        } catch {
+            XCTAssertEqual(error as? BroadcastError, .noConnection)
+        }
+    }
+
+    func testReceive() throws {
+        let expectation = self.expectation(description: "Receive audio frame")
+        let sender = BroadcastAudioSender(filePath: filePath)
+        let delegate = BroadcastAudioReceiverDelegateMock()
+
+        delegate.onReceive = { audioFrame in
+            XCTAssertEqual(audioFrame.streamDescription.mSampleRate, 44100)
+            expectation.fulfill()
+        }
+
+        receiver.delegate = delegate
+        try receiver.start()
+        try sender.start()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            sender.send(.audioStub())
+        }
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testStop() throws {
+        try receiver.start()
+        XCTAssertTrue(fileManager.fileExists(atPath: filePath))
+        XCTAssertTrue(receiver.isRunning)
+
+        try receiver.stop()
+        XCTAssertFalse(fileManager.fileExists(atPath: filePath))
+        XCTAssertFalse(receiver.isRunning)
+    }
+
+    func testStopWhenNotRunning() throws {
+        XCTAssertFalse(try receiver.stop())
+    }
+
+    func testStopOnDeinit() throws {
+        try receiver.start()
+        XCTAssertTrue(fileManager.fileExists(atPath: filePath))
+
+        receiver = nil
+        XCTAssertFalse(fileManager.fileExists(atPath: filePath))
+    }
+}
+
+// MARK: - Mocks
+
+final class BroadcastAudioReceiverDelegateMock: BroadcastAudioReceiverDelegate {
+    var onReceive: ((AudioFrame) -> Void)?
+
+    func broadcastAudioReceiver(
+        _ receiver: BroadcastAudioReceiver,
+        didReceiveAudioFrame frame: AudioFrame
+    ) {
+        onReceive?(frame)
+    }
+}
+
+#endif

--- a/Tests/PexipScreenCaptureTests/iOS/Internal/Audio/BroadcastAudioSenderTests.swift
+++ b/Tests/PexipScreenCaptureTests/iOS/Internal/Audio/BroadcastAudioSenderTests.swift
@@ -1,0 +1,104 @@
+//
+// Copyright 2024 Pexip AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if os(iOS)
+
+import XCTest
+import CoreMedia
+@testable import PexipScreenCapture
+
+final class BroadcastAudioSenderTests: XCTestCase {
+    private var sender: BroadcastAudioSender!
+    private var receiver: BroadcastAudioReceiver!
+    private let filePath = NSTemporaryDirectory().appending("/test")
+    private let fileManager = FileManager.default
+
+    // MARK: - Setup
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sender = BroadcastAudioSender(filePath: filePath)
+        receiver = BroadcastAudioReceiver(filePath: filePath)
+        try receiver.start()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        sender.stop()
+        try receiver.stop()
+        try? fileManager.removeItem(atPath: filePath)
+    }
+
+    // MARK: - Tests
+
+    func testStart() throws {
+        XCTAssertTrue(try sender.start())
+        XCTAssertTrue(sender.isRunning)
+    }
+
+    func testStartWhenRunning() throws {
+        XCTAssertTrue(try sender.start())
+        XCTAssertTrue(sender.isRunning)
+
+        XCTAssertFalse(try sender.start())
+        XCTAssertTrue(sender.isRunning)
+    }
+
+    func testStartWithNoFile() throws {
+        // 1. Create receiver with invalid file path
+        sender = BroadcastAudioSender(filePath: "test")
+
+        // 2. Try to start sender
+        do {
+            try sender.start()
+        } catch {
+            XCTAssertEqual(error as? BroadcastError, .noConnection)
+        }
+    }
+
+    func testSend() throws {
+        let expectation = self.expectation(description: "Receive audio frame")
+        let delegate = BroadcastAudioReceiverDelegateMock()
+        let sampleBuffer = CMSampleBuffer.audioStub()
+
+        delegate.onReceive = { audioFrame in
+            XCTAssertEqual(audioFrame.streamDescription.mSampleRate, 44100)
+            expectation.fulfill()
+        }
+
+        receiver.delegate = delegate
+        try sender.start()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            XCTAssertEqual(self?.sender.send(sampleBuffer), true)
+        }
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testStop() throws {
+        try sender.start()
+        XCTAssertTrue(sender.isRunning)
+
+        sender.stop()
+        XCTAssertFalse(sender.isRunning)
+    }
+
+    func testStopWhenNotRunning() {
+        XCTAssertFalse(sender.stop())
+    }
+}
+
+#endif

--- a/Tests/PexipScreenCaptureTests/iOS/Internal/Extensions/FileManagerBroadcastTests.swift
+++ b/Tests/PexipScreenCaptureTests/iOS/Internal/Extensions/FileManagerBroadcastTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,6 +35,11 @@ final class FileManagerBroadcastTests: XCTestCase {
     func testBroadcastVideoDataPath() {
         let path = fileManager.broadcastVideoDataPath(appGroup: "Test")
         XCTAssertTrue(path.hasSuffix("pex_broadcast_video"))
+    }
+
+    func testBroadcastAudioDataPath() {
+        let path = fileManager.broadcastAudioDataPath(appGroup: "Test")
+        XCTAssertTrue(path.hasSuffix("pex_broadcast_audio"))
     }
 
     func testBroadcastVideoDataPathWithNoContainerURL() {

--- a/Tests/PexipScreenCaptureTests/iOS/Internal/Video/BroadcastFpsTests.swift
+++ b/Tests/PexipScreenCaptureTests/iOS/Internal/Video/BroadcastFpsTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright -2024 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Tests/PexipScreenCaptureTests/iOS/Internal/Video/BroadcastFpsTests.swift
+++ b/Tests/PexipScreenCaptureTests/iOS/Internal/Video/BroadcastFpsTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright -2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Tests/PexipScreenCaptureTests/iOS/Internal/Video/BroadcastVideoReceiverTests.swift
+++ b/Tests/PexipScreenCaptureTests/iOS/Internal/Video/BroadcastVideoReceiverTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright -2024 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Tests/PexipScreenCaptureTests/iOS/Internal/Video/BroadcastVideoReceiverTests.swift
+++ b/Tests/PexipScreenCaptureTests/iOS/Internal/Video/BroadcastVideoReceiverTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright -2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ final class BroadcastVideoReceiverTests: XCTestCase {
         let maxTimeInterval = CMTime(fps: fps.value)
         var lastTime: CMTime?
         var iteration = 0
-        let delegate = BroadcastReceiverDelegateMock()
+        let delegate = BroadcastVideoReceiverDelegateMock()
 
         delegate.onReceive = { _ in
             let currentTime = CMClockGetTime(CMClockGetHostTimeClock())
@@ -136,7 +136,7 @@ final class BroadcastVideoReceiverTests: XCTestCase {
 
 // MARK: - Mocks
 
-final class BroadcastReceiverDelegateMock: BroadcastVideoReceiverDelegate {
+final class BroadcastVideoReceiverDelegateMock: BroadcastVideoReceiverDelegate {
     var onReceive: ((VideoFrame) -> Void)?
 
     func broadcastVideoReceiver(

--- a/Tests/PexipScreenCaptureTests/iOS/Internal/Video/BroadcastVideoSenderTests.swift
+++ b/Tests/PexipScreenCaptureTests/iOS/Internal/Video/BroadcastVideoSenderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright -2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ final class BroadcastVideoSenderTests: XCTestCase {
     func testSend() throws {
         let expectation = self.expectation(description: "Receive video frame")
         let receiver = BroadcastVideoReceiver(filePath: filePath)
-        let delegate = BroadcastReceiverDelegateMock()
+        let delegate = BroadcastVideoReceiverDelegateMock()
         let width = 1920
         let height = 1080
         let sampleBuffer = CMSampleBuffer.stub(width: width, height: height)
@@ -90,7 +90,7 @@ final class BroadcastVideoSenderTests: XCTestCase {
         XCTAssertFalse(sender.send(sampleBuffer))
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-            XCTAssertTrue(self?.sender.send(sampleBuffer) == true)
+            XCTAssertEqual(self?.sender.send(sampleBuffer), true)
         }
 
         wait(for: [expectation], timeout: 1)

--- a/Tests/PexipScreenCaptureTests/iOS/Internal/Video/BroadcastVideoSenderTests.swift
+++ b/Tests/PexipScreenCaptureTests/iOS/Internal/Video/BroadcastVideoSenderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright -2024 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Tests/PexipScreenCaptureTests/iOS/Internal/Video/MemoryMappedFileTests.swift
+++ b/Tests/PexipScreenCaptureTests/iOS/Internal/Video/MemoryMappedFileTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright -2024 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Tests/PexipScreenCaptureTests/iOS/Internal/Video/MemoryMappedFileTests.swift
+++ b/Tests/PexipScreenCaptureTests/iOS/Internal/Video/MemoryMappedFileTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright -2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,14 +61,14 @@ final class MemoryMappedFileTests: XCTestCase {
         )
     }
 
-    func testReadWrite() throws {
-        let data = try XCTUnwrap("test".data(using: .utf8))
+    func testReadWrite() {
+        let data = Data("test".utf8)
         XCTAssertTrue(file.write(data))
         XCTAssertEqual(file.read(), data)
     }
 
-    func testReadWriteWithDataSizeBiggerThanFileSize() throws {
-        let data = try XCTUnwrap("test2".data(using: .utf8))
+    func testReadWriteWithDataSizeBiggerThanFileSize() {
+        let data = Data("test2".utf8)
         XCTAssertFalse(file.write(data))
         XCTAssertNotEqual(file.read(), data)
     }

--- a/Tests/PexipScreenCaptureTests/macOS/Internal/Legacy/LegacyDisplayCapturerTests.swift
+++ b/Tests/PexipScreenCaptureTests/macOS/Internal/Legacy/LegacyDisplayCapturerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022-2024 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -340,9 +340,11 @@ private extension IOSurfaceRef {
 
 final class ScreenMediaCapturerDelegateMock: ScreenMediaCapturerDelegate {
     var onVideoFrame: ((VideoFrame) -> Void)?
+    var onAudioFrame: ((AudioFrame) -> Void)?
     var onStart: (() -> Void)?
     var onStop: ((Error?) -> Void)?
     private(set) var status: VideoFrame.Status?
+    private(set) var lastAudioFrame: AudioFrame?
 
     func screenMediaCapturer(
         _ capturer: ScreenMediaCapturer,
@@ -350,6 +352,14 @@ final class ScreenMediaCapturerDelegateMock: ScreenMediaCapturerDelegate {
     ) {
         status = .complete(frame)
         onVideoFrame?(frame)
+    }
+
+    func screenMediaCapturer(
+        _ capturer: any ScreenMediaCapturer,
+        didCaptureAudioFrame frame: AudioFrame
+    ) {
+        lastAudioFrame = frame
+        onAudioFrame?(frame)
     }
 
     func screenMediaCapturerDidStart(_ capturer: ScreenMediaCapturer) {


### PR DESCRIPTION
Add the possibility to capture screen audio on iOS and macOS. I think it's time to move this to `main` as the feature was implemented a while ago.

It's not possible to test it in the Demo app as the current WebRTC version in use doesn't support that.