### PR TITLE
fix(ScreenCapture): blocky video frame updates

### DIFF
--- a/Sources/PexipInfinityClient/Participants/Participant.swift
+++ b/Sources/PexipInfinityClient/Participants/Participant.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022-2025 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ public struct Participant: Codable, Hashable, Identifiable {
         id: String,
         displayName: String,
         localAlias: String = "",
-        overlayText: String = "",
+        overlayText: String? = nil,
         role: Participant.Role,
         serviceType: Participant.ServiceType,
         buzzTime: TimeInterval = 0,
@@ -122,7 +122,7 @@ public struct Participant: Codable, Hashable, Identifiable {
     /// The calling or "from" alias. This is the alias that the recipient would use to return the call.
     public let localAlias: String
     /// Text that may be used as an alternative to display_name as the participant name overlay text.
-    public let overlayText: String
+    public let overlayText: String?
     /// The level of privileges the participant has in the conference.
     public let role: Role
     /// The service type.

--- a/Sources/PexipScreenCapture/iOS/Internal/Extensions/CVPixelBuffer+Broadcast.swift
+++ b/Sources/PexipScreenCapture/iOS/Internal/Extensions/CVPixelBuffer+Broadcast.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2023-2025 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,6 +38,39 @@ extension CVPixelBuffer {
             bytesPerRow: CVPixelBufferGetBytesPerRowOfPlane(self, index),
             height: CVPixelBufferGetHeightOfPlane(self, index)
         )
+    }
+}
+
+extension CVPixelBufferPool {
+    static func createWithAttributes(
+        width: UInt32,
+        height: UInt32,
+        pixelFormat: OSType
+    ) -> CVPixelBufferPool? {
+        var pool: CVPixelBufferPool?
+        let attributes: NSDictionary = [
+            kCVPixelBufferPixelFormatTypeKey: pixelFormat,
+            kCVPixelBufferWidthKey: width,
+            kCVPixelBufferHeightKey: height,
+            kCVPixelBufferMetalCompatibilityKey: true,
+            kCVPixelBufferIOSurfacePropertiesKey: NSDictionary()
+        ]
+        CVPixelBufferPoolCreate(kCFAllocatorDefault, nil, attributes, &pool)
+        return pool
+    }
+
+    static func createWithTemplate(_ template: CVPixelBuffer) -> CVPixelBufferPool? {
+        createWithAttributes(
+            width: template.width,
+            height: template.height,
+            pixelFormat: template.pixelFormat
+        )
+    }
+
+    func createPixelBuffer() -> CVPixelBuffer? {
+        var pixelBuffer: CVPixelBuffer?
+        CVPixelBufferPoolCreatePixelBuffer(nil, self, &pixelBuffer)
+        return pixelBuffer
     }
 }
 

--- a/Sources/PexipScreenCapture/iOS/Internal/Extensions/Data+Broadcast.swift
+++ b/Sources/PexipScreenCapture/iOS/Internal/Extensions/Data+Broadcast.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 Pexip AS
+// Copyright 2022-2025 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,5 +21,10 @@ extension Data {
             return nil
         }
         return Data(bytesNoCopy: pointer, count: size, deallocator: .free)
+    }
+
+    mutating func append(start: UnsafeRawPointer?, count: Int) {
+        let pointer = UnsafeRawBufferPointer(start: start, count: count)
+        append(contentsOf: pointer)
     }
 }

--- a/Sources/PexipScreenCapture/iOS/Internal/Video/MemoryMappedFile.swift
+++ b/Sources/PexipScreenCapture/iOS/Internal/Video/MemoryMappedFile.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2024 Pexip AS
+// Copyright 2023-2025 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ final class MemoryMappedFile {
 
         data.withUnsafeBytes { pointer in
             if let baseAddress = pointer.baseAddress {
-                memcpy(memory, baseAddress, data.count)
+                memory.copyMemory(from: baseAddress, byteCount: data.count)
             }
         }
 

--- a/Sources/PexipScreenCapture/iOS/Internal/Video/PixelTransferSession.swift
+++ b/Sources/PexipScreenCapture/iOS/Internal/Video/PixelTransferSession.swift
@@ -1,0 +1,84 @@
+//
+// Copyright 2025 Pexip AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if os(iOS)
+
+import Foundation
+import VideoToolbox
+
+// MARK: - Protocol
+
+protocol PixelTransferSession {
+    func transfer(_ inputBuffer: CVPixelBuffer) -> CVPixelBuffer
+}
+
+// MARK: - Implementation
+
+@available(iOS 16.0, *)
+final class VideoToolboxTransferSession: PixelTransferSession {
+    private var session: VTPixelTransferSession?
+    private var bufferPool: CVPixelBufferPool?
+    private var width: UInt32 = 0
+    private var height: UInt32 = 0
+
+    // MARK: - Init
+
+    init() {
+        VTPixelTransferSessionCreate(
+            allocator: nil,
+            pixelTransferSessionOut: &session
+        )
+    }
+
+    deinit {
+        if let session {
+            VTPixelTransferSessionInvalidate(session)
+            self.session = nil
+        }
+    }
+
+    // MARK: - Transfer
+
+    func transfer(_ inputBuffer: CVPixelBuffer) -> CVPixelBuffer {
+        inputBuffer.lockBaseAddress(.readOnly)
+
+        defer {
+            inputBuffer.unlockBaseAddress(.readOnly)
+        }
+
+        if bufferPool == nil || inputBuffer.width != width || inputBuffer.height != height {
+            bufferPool = CVPixelBufferPool.createWithTemplate(inputBuffer)
+            width = inputBuffer.width
+            height = inputBuffer.height
+        }
+
+        guard let bufferPool else {
+            return inputBuffer
+        }
+
+        var outputBuffer: CVPixelBuffer?
+        CVPixelBufferPoolCreatePixelBuffer(nil, bufferPool, &outputBuffer)
+
+        guard let session, let outputBuffer else {
+            return inputBuffer
+        }
+
+        VTPixelTransferSessionTransferImage(session, from: inputBuffer, to: outputBuffer)
+
+        return outputBuffer
+    }
+}
+
+#endif

--- a/Tests/PexipInfinityClientTests/Participants/ParticipantTests.swift
+++ b/Tests/PexipInfinityClientTests/Participants/ParticipantTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2022-2023 Pexip AS
+// Copyright 2022-2025 Pexip AS
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -118,7 +118,7 @@ final class ParticipantTests: XCTestCase {
         XCTAssertEqual(participant.id, id)
         XCTAssertEqual(participant.displayName, "Test")
         XCTAssertTrue(participant.localAlias.isEmpty)
-        XCTAssertTrue(participant.overlayText.isEmpty)
+        XCTAssertNil(participant.overlayText?.isEmpty)
         XCTAssertEqual(participant.role, .chair)
         XCTAssertEqual(participant.serviceType, .conference)
         XCTAssertEqual(participant.buzzTime, 0)
@@ -173,7 +173,7 @@ final class ParticipantTests: XCTestCase {
         XCTAssertEqual(participant.id, id)
         XCTAssertEqual(participant.displayName, "Test")
         XCTAssertTrue(participant.localAlias.isEmpty)
-        XCTAssertTrue(participant.overlayText.isEmpty)
+        XCTAssertNil(participant.overlayText)
         XCTAssertEqual(participant.role, .chair)
         XCTAssertEqual(participant.serviceType, .conference)
         XCTAssertEqual(participant.buzzTime, 0)


### PR DESCRIPTION
This PR aims to fix consistency issues with video captured using ReplayKit on iOS 16+ from a broadcast extension. When attempting to access and copy the video buffer memory using the CPU (via memcpy), it appeared as though the next frame was bleeding into the current one. Using the `VideoToolboxTransferSession` to copy pixel buffers before sending them to the main app resolves the issue on iOS 16+, without significant increases in memory usage or CPU load.